### PR TITLE
fix(session): オープニング選択肢の隣接ノード整合 (Issue #4 / I2)

### DIFF
--- a/backend/app/modules/session/service.py
+++ b/backend/app/modules/session/service.py
@@ -1479,6 +1479,14 @@ def _input_has_movement_intent(input_text: str) -> bool:
     return any(token in input_text for token in ("向か", "行く", "行き", "移る", "移動", "入る", "戻る", "go ", "travel", "head", "enter", "return"))
 
 
+def _route_destination_key(route: dict[str, Any]) -> str:
+    return str(
+        route.get("destination_key")
+        or ((route.get("to_location") or {}).get("key") if isinstance(route.get("to_location"), dict) else "")
+        or ""
+    ).strip()
+
+
 def _match_visible_route_by_public_text(
     db: Session,
     *,
@@ -1489,12 +1497,35 @@ def _match_visible_route_by_public_text(
     alias_index: CanonicalPublicAliasIndex,
     key_candidate: str | None = None,
 ) -> dict[str, Any] | None:
+    available_routes = [
+        route
+        for route in session_state.get("nearby_routes") or []
+        if isinstance(route, dict) and bool(route.get("available"))
+    ]
+    if not available_routes:
+        return None
+
+    # When the AI GM asserts the scene is at a place reachable by an open,
+    # one-hop adjacent route, the location claim itself is the movement signal:
+    # the player is narrated as already standing at that currently-open
+    # destination, so resolve the implicit travel regardless of explicit
+    # movement verbs. This keeps in-town facilities consistent with the hub
+    # starter location (e.g. the guild hall a freshly registered adventurer is
+    # described inside) without weakening protection against non-adjacent or
+    # locked destinations, which never appear among the available routes.
+    if claim_text:
+        matched_claim = alias_index.match_location(claim_text, key_candidate=key_candidate)
+        if matched_claim is not None:
+            for route in available_routes:
+                if _route_destination_key(route) == matched_claim.canonical_key:
+                    return route
+
+    # Free-text detection: only treat the action itself as travel when it
+    # expresses movement intent and names the destination by a public alias.
     if not _input_has_movement_intent(player_action_text):
         return None
-    for route in session_state.get("nearby_routes") or []:
-        if not isinstance(route, dict) or not bool(route.get("available")):
-            continue
-        destination_key = str(route.get("destination_key") or ((route.get("to_location") or {}).get("key") if isinstance(route.get("to_location"), dict) else "") or "").strip()
+    for route in available_routes:
+        destination_key = _route_destination_key(route)
         aliases = alias_index.aliases_for_location(destination_key) or _route_public_aliases(db, world_id, route)
         if not _text_mentions_public_alias(player_action_text, aliases):
             continue

--- a/packs/ashlight_frontier/world_templates.yaml
+++ b/packs/ashlight_frontier/world_templates.yaml
@@ -273,8 +273,8 @@ world_templates:
         name: Adventurers Guild Hall
         description: The guild hall inside Lieber Lampfort, where a living board gathers notes, requests, rumors, witness fragments, and unfinished reports.
         public_aliases:
-          en: [Adventurers Guild Hall, guild hall, guild board, reception desk]
-          ja: [冒険者ギルド広間, ギルド広間, 掲示板, 受付]
+          en: [Adventurers Guild Hall, Adventurers Guild, guild hall, guild board, reception desk]
+          ja: [冒険者ギルド広間, 冒険者ギルド, ギルド広間, 掲示板, 受付]
         hierarchy: town_facility
         region: lieber_lampfort
         kind: guild_hall

--- a/tests/backend/packs/ashlight_frontier/test_ashlight_frontier_pack.py
+++ b/tests/backend/packs/ashlight_frontier/test_ashlight_frontier_pack.py
@@ -5,8 +5,19 @@ from pathlib import Path
 
 from sqlalchemy import select
 
-from app.models.entities import Actor, Event, Location, LocationRoute, QuestAssignment, World
-from app.modules.world_state.service import _route_accessible, apply_active_quest_resolution
+from app.models.entities import Actor, Event, Location, LocationRoute, QuestAssignment, Turn, World
+from app.modules.llm_harness.service import ProviderResponse
+from app.modules.session.service import (
+    _build_canonical_public_alias_index,
+    _enrich_public_turn_session_state,
+    _match_visible_route_by_public_text,
+)
+from app.modules.world_state.service import (
+    _route_accessible,
+    apply_active_quest_resolution,
+    build_session_state,
+)
+from tests.backend.turn_async_helpers import post_turn_and_wait
 
 
 REPO_ROOT = next(parent for parent in Path(__file__).resolve().parents if (parent / "AGENTS.md").exists())
@@ -194,3 +205,174 @@ def test_resolving_opening_thread_unlocks_mistbound_access_emergently(client, co
         db.refresh(locked_route)
         # Emergent access: the frontier opens once the opening thread is resolved.
         assert _route_accessible(db, world_id=world_id, route=locked_route, actor_id=actor_id) is True
+
+
+def _guild_receptionist(db) -> Actor:
+    """The guide receptionist (Elna) is materialized inside the guild hall, one
+    open hop from the hub starter location `lieber_lampfort`."""
+    guild_hall = next(
+        location
+        for location in db.execute(select(Location).where(Location.world_id == "ashlight_frontier")).scalars()
+        if (location.state or {}).get("key") == "adventurers_guild_hall"
+    )
+    guide = db.execute(
+        select(Actor).where(
+            Actor.world_id == "ashlight_frontier",
+            Actor.actor_type == "npc",
+            Actor.display_name == "Guild Receptionist Elna",
+        )
+    ).scalars().first()
+    assert guide is not None, "the guild receptionist should be seeded for ashlight_frontier"
+    assert guide.current_location_id == guild_hall.id, "Elna lives in the guild hall, not the hub starter node"
+    return guide
+
+
+def test_guild_hall_location_claim_resolves_without_movement_verb(client, container, auth_headers):
+    """Issue #4 (I2): a narrative opening choice whose scene the GM places in the
+    open-route-adjacent guild hall must resolve as an implicit travel, even
+    without an explicit movement verb, instead of being rejected."""
+    response = client.post("/sessions", json=ashlight_session_payload(), headers=auth_headers)
+    assert response.status_code == 200
+
+    with container.session_factory() as db:
+        actor = db.execute(
+            select(Actor).where(Actor.world_id == "ashlight_frontier", Actor.actor_type == "player")
+        ).scalar_one()
+        assert (
+            db.execute(select(Location).where(Location.world_id == "ashlight_frontier", Location.id == actor.current_location_id))
+            .scalar_one()
+            .state["key"]
+            == "lieber_lampfort"
+        )
+        state = build_session_state(
+            db,
+            world_id="ashlight_frontier",
+            actor_id=actor.id,
+            location_id=actor.current_location_id,
+            include_internal=True,
+        )
+        state.pop("next_choices", None)
+        state = _enrich_public_turn_session_state(
+            db,
+            world_id="ashlight_frontier",
+            actor_id=actor.id,
+            session_state=state,
+        )
+        alias_index = _build_canonical_public_alias_index(db, "ashlight_frontier", state)
+
+        # "眺める" carries no movement verb, but the GM asserting the guild-hall
+        # scene as the current location is itself the movement signal.
+        route = _match_visible_route_by_public_text(
+            db,
+            world_id="ashlight_frontier",
+            session_state=state,
+            claim_text="冒険者ギルド広間",
+            player_action_text="掲示板を眺め、自分が気になる問題の方向を探す",
+            alias_index=alias_index,
+        )
+        assert route is not None
+        assert route["destination_key"] == "adventurers_guild_hall"
+
+        # Without any location claim and without movement intent, a free-text
+        # action must NOT silently teleport the player.
+        assert (
+            _match_visible_route_by_public_text(
+                db,
+                world_id="ashlight_frontier",
+                session_state=state,
+                claim_text="",
+                player_action_text="掲示板を眺める",
+                alias_index=alias_index,
+            )
+            is None
+        )
+
+        # The strengthened short alias "冒険者ギルド" resolves an explicit move
+        # even though the canonical node name is "冒険者ギルド広間".
+        partial_alias_route = _match_visible_route_by_public_text(
+            db,
+            world_id="ashlight_frontier",
+            session_state=state,
+            claim_text="",
+            player_action_text="冒険者ギルドへ向かう",
+            alias_index=alias_index,
+        )
+        assert partial_alias_route is not None
+        assert partial_alias_route["destination_key"] == "adventurers_guild_hall"
+
+
+def test_opening_guild_choice_resolves_via_implicit_adjacent_travel(client, container, auth_headers):
+    """Issue #4 (I2) regression: choice_1/choice_2 narrative openings that the GM
+    sets inside the guild hall (with the receptionist present) used to fail with
+    `repair_failed` because the player starts one open hop away at the hub. They
+    must now resolve by implicitly relocating the player into the guild hall."""
+    session_response = client.post("/sessions", json=ashlight_session_payload(), headers=auth_headers)
+    assert session_response.status_code == 200
+    session_id = session_response.json()["session_id"]
+
+    with container.session_factory() as db:
+        guide_name = _guild_receptionist(db).display_name
+
+    original_generate = container.model_router.provider.generate
+
+    def guild_scene_generate(**kwargs):
+        prompt = kwargs["prompt"]
+        if prompt.prompt_id not in {"session.turn_resolution", "session.turn_resolution_repair"}:
+            return original_generate(**kwargs)
+        return ProviderResponse(
+            raw_output={
+                "action_interpretation": "新米冒険者は受付に近づき、最近の相談の傾向を尋ねている。",
+                "narrative": (
+                    f"{guide_name}は掲示板の断片的な相談を指し示し、"
+                    "最近増えている気がかりの種類を、まだ依頼名にはせずに落ち着いて並べてみせた。"
+                ),
+                "current_situation": "冒険者ギルド広間では、受付と掲示板の周りに相談や噂が集まっている。",
+                "current_location_name": "冒険者ギルド広間",
+                "suggested_actions": [
+                    {"label": "掲示板の相談を一つ選ぶ", "summary": "気になる方向を一つ選んで深掘りする。"},
+                    {"label": "受付にもう少し詳しく尋ねる", "summary": "相談の背景を確認する。"},
+                ],
+                "consequence_summary": "受付と掲示板から、最近の相談の傾向が見えてきた。",
+                "world_tags": ["investigate"],
+                "consequence_tags": ["careful_observation"],
+                "scene_tone": "measured",
+                "scene_move": "deepen",
+                "scene_pressure": "low",
+                "memories": [
+                    {"scope": "world", "text": "新米冒険者は受付で相談の傾向を尋ねた。", "salience": 0.6}
+                ],
+                "language_context": {
+                    "pack_source_language": "en",
+                    "play_language": "ja",
+                    "output_language_requested": "ja",
+                },
+                "public_claims": [
+                    {"kind": "location", "surface_text": "冒険者ギルド広間", "language": "ja", "role": "current_location"},
+                    {"kind": "actor", "surface_text": guide_name, "language": "ja", "role": "present"},
+                ],
+                "present_people": [guide_name],
+            },
+            provider_name="test",
+            provider_response_id=None,
+        )
+
+    container.model_router.provider.generate = guild_scene_generate
+    try:
+        _, data, _ = post_turn_and_wait(
+            client,
+            session_id=session_id,
+            auth_headers=auth_headers,
+            payload={"player_action_text": "ギルド受付に、いま多い相談の傾向を聞く"},
+        )
+    finally:
+        container.model_router.provider.generate = original_generate
+
+    assert data.get("system_message") is None, data
+    assert data.get("failure") is None, data
+    assert data["current_location"]["key"] == "adventurers_guild_hall"
+
+    with container.session_factory() as db:
+        turn = db.get(Turn, data["turn_id"])
+        assert turn is not None
+        assert turn.resolved_output["status"] == "resolved"
+        assert not turn.resolved_output["rejected_claims"], turn.resolved_output["rejected_claims"]


### PR DESCRIPTION
Closes #4 (テストプレイ I2)

## 背景 / 現象
開始ハブ `lieber_lampfort` に対し、ガイドNPCエルナ(pack-seed `is_guide`, `home_location_key: adventurers_guild_hall`)と掲示板は別ノード `adventurers_guild_hall` に在席。ギルド広間・エルナを描く narrative オープニング選択肢(choice_1「ギルド受付に聞く」/ choice_2「掲示板を眺める」)が整合性ハーネスに「場所主張≠現在地」「エルナ非同席」で却下され、repair も同じ不可達先を再幻覚して `repair_failed` になっていた(first-play の最初の数手が壊れる)。

## 修正方針(ハーネス隣接認識化)
`_match_visible_route_by_public_text` を再構成:

- **claim パス(新)**: GM が「現在地」として開ルートで1ホップ隣接する場所を主張したら、移動意図動詞の有無にかかわらず暗黙 travel として解決。`effective_location_id` がギルド広間へ更新され、再計算される可視人物にエルナが含まれるため、**場所・同席の両却下が同時に解消**する。
- **free-text パス(従来維持)**: claim 無しの場合は `_input_has_movement_intent` + エイリアス言及を要求 → 誤テレポート防止。非隣接・locked 先は引き続き却下。
- `adventurers_guild_hall` に短縮エイリアス「冒険者ギルド」/「Adventurers Guild」を追加(T13 系の明示移動入力の取りこぼし対策)。

pack の開始位置・トポロジ(ハブ&スポーク)は変更しないため、choice_3(外門への travel)と自由移動は劣化なし、テレポート防御も維持。

## 変更ファイル
- `backend/app/modules/session/service.py` — `_match_visible_route_by_public_text` 再構成 + `_route_destination_key` ヘルパ
- `packs/ashlight_frontier/world_templates.yaml` — 短縮エイリアス追加
- `tests/backend/packs/ashlight_frontier/test_ashlight_frontier_pack.py` — リグレッションテスト2件 + ヘルパ

## 検証
- `tests/backend/packs/ashlight_frontier` … 5 passed
- `test_public_ai_gm_contract.py` + `gestaloka_world_reference` … 27 passed(非隣接却下の負例・matcher 直接テスト含む)
- `test_api_contracts.py`(travel ターン)… 41 passed
- `make scan-v1-terms` … クリーン

## 対象外(別 issue)
- **I3**(却下後の優雅なフォールバック / repair プロンプトへの正準位置・同席NPC・可視ルート制約注入 / N回却下時の決定論フォールバック)は範囲外。

🤖 Generated with [Claude Code](https://claude.com/claude-code)