### PR TITLE
fix(session): 整合性ハーネス却下後の決定論フォールバック (Issue #5 / I3)

### DIFF
--- a/backend/app/modules/gm_council/service.py
+++ b/backend/app/modules/gm_council/service.py
@@ -953,6 +953,25 @@ def _public_validation_feedback(items: list[dict[str, Any]]) -> list[dict[str, s
     return feedback or [{"reason": "consistency_failed", "message": "The output must be repaired to match visible public state."}]
 
 
+def _split_rejected_claim_names(rejected_claims: list[dict[str, Any]] | None) -> tuple[list[str], list[str]]:
+    """Split harness rejected claims into ordered, de-duplicated lists of
+    unreachable place names and absent person names for fallback narration."""
+    unreachable_places: list[str] = []
+    absent_people: list[str] = []
+    for item in rejected_claims or []:
+        if not isinstance(item, dict):
+            continue
+        name = _compact_text(item.get("claim"))
+        if not name:
+            continue
+        claim_kind = str(item.get("claim_kind") or "")
+        if claim_kind == "location" and name not in unreachable_places:
+            unreachable_places.append(name)
+        elif claim_kind == "actor" and name not in absent_people:
+            absent_people.append(name)
+    return unreachable_places, absent_people
+
+
 def _public_text(value: Any) -> str:
     return _compact_text(value)
 
@@ -1260,6 +1279,45 @@ class GMCouncilService:
             deterministic_fallback_used=False,
         )
 
+    def fallback_public_turn(
+        self,
+        request: CouncilRequest,
+        *,
+        rejected_claims: list[dict[str, Any]] | None = None,
+        previous_role_runs: list[CouncilRoleRun] | None = None,
+        original_failure_reason: str | None = None,
+    ) -> TurnResolutionOutcome:
+        """Deterministically resolve a turn at the current location when the AI GM
+        and its repair attempt keep hallucinating unreachable places or absent
+        people (Issue #5 / I3). Produces a minimal, harness-clean narrative so the
+        whole turn is not failed; the rejected claims are recorded for audit."""
+        cleaned_claims = [item for item in (rejected_claims or []) if isinstance(item, dict)]
+        public_payload = self._public_turn_fallback_payload(request, rejected_claims=cleaned_claims)
+        final_payload = self._public_turn_to_resolution_payload(request, public_payload)
+        final_payload.event_payload = {
+            **final_payload.event_payload,
+            "deterministic_fallback": {
+                "reason": original_failure_reason or "consistency_failed",
+                "rejected_claims": cleaned_claims[:6],
+            },
+        }
+        fallback_role_run = CouncilRoleRun(
+            council_role="ai_gm_fallback",
+            stage_index=3,
+            prompt_id="session.turn_resolution_fallback",
+            approval_status="approved",
+            attempts=[],
+            final_lane="deterministic",
+            final_payload=public_payload.model_dump(),
+            failure_reason=None,
+        )
+        return TurnResolutionOutcome(
+            role_runs=[*(previous_role_runs or []), fallback_role_run],
+            final_lane="deterministic",
+            final_payload=final_payload,
+            deterministic_fallback_used=True,
+        )
+
     def _public_turn_input_payload(self, request: CouncilRequest) -> dict[str, Any]:
         player_profile = request.session_state.get("player_profile") or {}
         play_language = _play_language_context(player_profile)
@@ -1276,7 +1334,12 @@ class GMCouncilService:
             "recent_memories": [_public_text(item) for item in request.relevant_memories if _public_text(item)][:6],
         }
 
-    def _public_turn_fallback_payload(self, request: CouncilRequest) -> PublicGmTurnPayload:
+    def _public_turn_fallback_payload(
+        self,
+        request: CouncilRequest,
+        *,
+        rejected_claims: list[dict[str, Any]] | None = None,
+    ) -> PublicGmTurnPayload:
         input_payload = self._public_turn_input_payload(request)
         public_context = input_payload["public_game_context"]
         current_location = public_context.get("current_location") if isinstance(public_context, dict) else {}
@@ -1287,6 +1350,7 @@ class GMCouncilService:
         visible_exits = public_context.get("visible_exits") if isinstance(public_context, dict) else []
         visible_exits = [item for item in visible_exits or [] if isinstance(item, dict)]
         exit_name = _first_text((visible_exits[0] or {}).get("destination_name")) if visible_exits else ""
+        unreachable_places, absent_people = _split_rejected_claim_names(rejected_claims)
         suggestions = [
             {"label": "直前の結果を案内役に確認する", "summary": "場面を進める前に、確認できた変化だけを整理する。"},
             {"label": f"{location_name}で次に見える記録を調べる", "summary": "現在地にある公開情報から次の糸口を探す。"},
@@ -1296,10 +1360,16 @@ class GMCouncilService:
             },
         ]
         action_phrase = _naturalize_turn_action_text(input_text)
+        narrative_parts = [f"{request.player_name}は{action_phrase}。"]
+        if unreachable_places:
+            narrative_parts.append(f"{'・'.join(unreachable_places[:2])}へ通じる道は、ここからは今のところ見当たらない。")
+        if absent_people:
+            narrative_parts.append(f"{'・'.join(absent_people[:2])}の姿は、この場には見当たらない。")
+        narrative_parts.append(f"{location_name}の状況は、確認できる範囲でだけ変化する。")
         return PublicGmTurnPayload.model_validate(
             {
                 "action_interpretation": input_text,
-                "narrative": f"{request.player_name}は{action_phrase}。{location_name}の状況は、確認できる範囲でだけ変化する。",
+                "narrative": "".join(narrative_parts),
                 "npc_reaction": f"{request.npc_name}は、その場で見える変化にだけ反応する。",
                 "current_situation": _first_text(current_location.get("description"), f"{location_name}で次の判断点が見えている。"),
                 "current_location_name": location_name,

--- a/backend/app/modules/session/service.py
+++ b/backend/app/modules/session/service.py
@@ -2218,7 +2218,12 @@ def _resolve_public_ai_gm_turn_for_session(
                 {
                     "reason": "consistency_failed",
                     "claim": str(item.get("claim") or ""),
-                    "message": str(item.get("reason") or "The output contradicted canonical public state."),
+                    "message": (
+                        f"{item.get('reason') or 'The output contradicted canonical public state.'} "
+                        f"Do NOT name '{item.get('claim') or ''}' again. It is not reachable/present from the current "
+                        "location. Either resolve the turn at public_game_context.current_location, or, if the player "
+                        "moves, name only a place in public_game_context.visible_exits."
+                    ).strip(),
                 }
                 for item in dry_run_harness_result["rejected_claims"]
                 if isinstance(item, dict)
@@ -2282,48 +2287,19 @@ def _resolve_public_ai_gm_turn_for_session(
             apply_changes=False,
         )
         if dry_run_harness_result["rejected_claims"]:
-            _persist_role_runs(
-                db,
-                world_id=game_session.world_id,
-                turn_id=turn.id,
-                workflow_name="ai_gm",
-                role_runs=resolution.role_runs,
-                graph_context_status="public_context",
+            # Issue #5 (I3): repair still hallucinated unreachable places / absent
+            # people. Rather than failing the whole turn (and re-producing the same
+            # hallucination on retry), deterministically resolve a minimal narrative
+            # that completes at the canonical current location. The fallback payload
+            # only claims the current location, so it passes the harness cleanly.
+            resolution = container.council_service.fallback_public_turn(
+                council_request,
+                rejected_claims=dry_run_harness_result["rejected_claims"],
+                previous_role_runs=resolution.role_runs,
+                original_failure_reason="consistency_failed",
             )
-            failed_result = _build_failed_turn_result(
-                db,
-                container,
-                prepared,
-                turn=turn,
-                action_type="narrative",
-                resolution_mode="ai_gm_harness",
-                action_label=input_text,
-                graph_context_status="public_context",
-                failure_reason="repair_failed",
-                model_lane=resolution.final_lane,
-                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
-                input_mode="free_text",
-                interpreted_intent=payload.interpreted_intent,
-                next_choices=session_state.get("suggested_actions") or [],
-                consequence_summary="アクションに失敗しました。SPは返却されました。",
-                progress_phases=progress_phases,
-                failure_payload={
-                    "failure_reason": "repair_failed",
-                    "failure_reason_code": "repair_failed",
-                    "rejected_claims": dry_run_harness_result["rejected_claims"],
-                    "normalization_warnings": payload.interpreted_intent.get("normalization_warnings", []),
-                    "retrieval_trace": retrieval_trace_to_dict(retrieval.trace),
-                    "council_trace": [
-                        {
-                            "role": item.council_role,
-                            "approval_status": item.approval_status,
-                            "final_lane": item.final_lane,
-                        }
-                        for item in resolution.role_runs
-                    ],
-                },
-            )
-            return failed_result
+            payload = resolution.final_payload
+            progress_phases = _progress_phases_from_role_runs(resolution.role_runs)
 
     _persist_role_runs(
         db,

--- a/prompts/session/turn_resolution_repair.yaml
+++ b/prompts/session/turn_resolution_repair.yaml
@@ -18,12 +18,15 @@ instructions: |
   - Treat player_action_text as the only player action.
   - Treat public_game_context as player-visible state, not hidden control data.
   - validation_feedback contains only public reasons the previous output could not be used. Fix those problems.
+  - HARD CONSTRAINT: Any place or person named in validation_feedback as not reachable or not present is FORBIDDEN. Do not name it again anywhere (narrative, current_situation, current_location_name, public_claims, present_people, suggested_actions). Re-using a rejected name is the most common repair failure; never do it.
+  - The only places you may move to are entries of public_game_context.visible_exits. The only people you may treat as present are public_game_context.visible_people. The only canonical current place is public_game_context.current_location. Anything outside these sets does not exist for this turn.
+  - If the player's action targeted a place or person that is forbidden by validation_feedback, do not silently substitute a different destination or person. Instead resolve the turn at public_game_context.current_location and let the narrative make clear, in-world, that the targeted place/person is not reachable or present from here right now.
   - Never assume hidden ids, target keys, route keys, choice ids, item ids, quest assignment ids, backend action types, or DB keys.
   - Do not quote player_action_text as a mechanical sentence. Restate the action in natural prose.
   - Write all player-facing result content in narrative. Do not create separate "reaction" or "change" sections.
   - current_location_name must be exactly one public place name: public_game_context.current_location.name or one visible_exits[].destination_name. Do not combine a place with an object or slash-separated investigation target.
   - If the player moves to a visible exit, narrative, current_situation, current_location_name, public_claims, present_people, visible_items, and suggested_actions must all describe the arrival place.
-  - If movement is not supported, keep all people/items/location claims grounded in public_game_context.current_location.
+  - If movement is not supported, keep all people/items/location claims grounded in public_game_context.current_location and public_game_context.visible_people only.
   - suggested_actions must be objects with label, summary, and optional risk_hint. They must be natural public text only and must reflect the repaired current situation.
   - public_claim.kind allowed values: location, actor, item, quest, fact.
   - public_claim.role allowed values: current_location, present, mentioned, used, destination, offered.

--- a/tests/backend/engine/test_public_ai_gm_contract.py
+++ b/tests/backend/engine/test_public_ai_gm_contract.py
@@ -304,24 +304,42 @@ def test_public_claim_key_candidate_cannot_move_without_matching_surface_text(cl
             session_id,
             auth_headers,
             "虚無領域へ向かう",
-            expected_event="turn.failed",
         )
         after_state = client.get(f"/sessions/{session_id}/state", headers=auth_headers).json()
     finally:
         container.model_router.provider.generate = original_generate
 
+    # The unmatched key_candidate still cannot move the player. Instead of failing
+    # the whole turn (and re-hallucinating on retry), the harness deterministically
+    # resolves a minimal narrative at the canonical current location (Issue #5 / I3).
     assert before_state["current_location"]["key"] == "nexus_city"
     assert payload["current_location"]["key"] == "nexus_city"
     assert after_state["current_location"]["key"] == "nexus_city"
     assert payload["location_updates"] == []
-    assert payload["system_message"] == "アクションに失敗しました。SPは返却されました。"
-    assert payload["failure"]["reason"] == "repair_failed"
-    assert payload["refund_ledger_id"]
+    assert payload.get("system_message") is None
+    assert payload.get("failure") is None
+    assert payload.get("refund_ledger_id") is None
+    assert payload["event_id"]
     with container.session_factory() as db:
         turn = db.get(Turn, payload["turn_id"])
         assert turn is not None
-        assert turn.resolved_output["status"] == "failed"
-        assert turn.resolved_output["rejected_claims"]
+        assert turn.resolved_output["status"] == "resolved"
+        assert turn.resolved_output["used_fallback"] is True
+        # The fallback payload only claims the current location, so the harness
+        # accepts it cleanly; no hallucinated move enters canonical state.
+        assert turn.resolved_output["rejected_claims"] == []
+        assert not any(
+            item.get("change_kind") == "location" for item in turn.resolved_output["accepted_state_changes"]
+        )
+        # The unreachable place is named in-world as unreachable, not as a move.
+        assert "虚無領域" in turn.resolved_output["narrative"]
+        assert "見当たらない" in turn.resolved_output["narrative"]
+        # The original hallucination is recorded on the fallback for audit.
+        event = db.get(Event, payload["event_id"])
+        assert event is not None
+        fallback = event.payload["deterministic_fallback"]
+        assert fallback["reason"] == "consistency_failed"
+        assert any(item.get("claim") == "虚無領域" for item in fallback["rejected_claims"])
 
 
 def test_public_visible_item_reference_is_not_unowned_item_use_failure(client, container, auth_headers):
@@ -391,7 +409,7 @@ def test_public_visible_item_reference_is_not_unowned_item_use_failure(client, c
         ]
 
 
-def test_harness_rejects_unavailable_location_claim_without_moving_player(client, container, auth_headers):
+def test_harness_unavailable_location_claim_falls_back_without_moving_player(client, container, auth_headers):
     original_generate = container.model_router.provider.generate
 
     def impossible_location_generate(**kwargs):
@@ -433,7 +451,89 @@ def test_harness_rejects_unavailable_location_claim_without_moving_player(client
             session_id,
             auth_headers,
             "周囲を確認する",
-            expected_event="turn.failed",
+        )
+        after_state = client.get(f"/sessions/{session_id}/state", headers=auth_headers).json()
+    finally:
+        container.model_router.provider.generate = original_generate
+
+    # The hallucinated move is rejected (player does not relocate), but instead of
+    # failing the turn the harness resolves a minimal narrative in place (Issue #5).
+    assert payload["current_location"]["name"] == before_state["current_location"]["name"]
+    assert after_state["current_location"]["name"] == before_state["current_location"]["name"]
+    assert payload["location_updates"] == []
+    assert payload.get("system_message") is None
+    assert payload.get("failure") is None
+    assert payload.get("refund_ledger_id") is None
+
+    with container.session_factory() as db:
+        turn = db.get(Turn, payload["turn_id"])
+        memories = db.execute(select(Memory).where(Memory.source_event_id == payload["event_id"])).scalars().all()
+        assert turn is not None
+        assert turn.resolved_output["status"] == "resolved"
+        assert turn.resolved_output["used_fallback"] is True
+        assert turn.resolved_output["rejected_claims"] == []
+        # The hallucinated NPC ("番人") is never materialized into canonical memory.
+        assert all("番人" not in memory.text for memory in memories)
+        event = db.get(Event, payload["event_id"])
+        assert event is not None
+        assert event.payload["deterministic_fallback"]["reason"] == "consistency_failed"
+
+
+def test_harness_repeated_absent_npc_hallucination_falls_back_in_place(client, container, auth_headers):
+    """Issue #5 (I3) regression: when both the first AI GM output and its repair
+    re-hallucinate the same absent NPC, the turn must not fail forever. The harness
+    deterministically resolves a minimal narrative in place that names the person as
+    absent, instead of returning repair_failed and refunding SP."""
+    original_generate = container.model_router.provider.generate
+    absent_npc_name = "忘却の審判官ヴェル"
+
+    def absent_npc_generate(**kwargs):
+        prompt = kwargs["prompt"]
+        if prompt.prompt_id not in {"session.turn_resolution", "session.turn_resolution_repair"}:
+            return original_generate(**kwargs)
+        # Both the initial output and the repair keep claiming the same NPC is here.
+        return ProviderResponse(
+            raw_output={
+                "action_interpretation": f"ヌートは{absent_npc_name}に話しかけようとしている。",
+                "narrative": f"{absent_npc_name}はヌートの問いに静かに頷いた。",
+                "npc_reaction": f"{absent_npc_name}は古い裁定の記憶を語り始めた。",
+                "current_situation": f"{absent_npc_name}が傍らに立っている。",
+                "suggested_actions": [
+                    {"label": "さらに尋ねる", "summary": "裁定の記憶を深掘りする。"},
+                    {"label": "周囲を見回す", "summary": "現在地の様子を確かめる。"},
+                ],
+                "consequence_summary": f"{absent_npc_name}との対話が始まった。",
+                "world_tags": ["investigate"],
+                "consequence_tags": ["careful_observation"],
+                "scene_tone": "measured",
+                "scene_move": "deepen",
+                "scene_pressure": "medium",
+                "memories": [{"scope": "world", "text": f"{absent_npc_name}が裁定の記憶を語った。", "salience": 0.7}],
+                "language_context": {
+                    "pack_source_language": "en",
+                    "play_language": "ja",
+                    "output_language_requested": "ja",
+                },
+                "present_people": [absent_npc_name],
+                "public_claims": [
+                    {"kind": "actor", "surface_text": absent_npc_name, "language": "ja", "role": "present"},
+                ],
+            },
+            provider_name="test",
+            provider_response_id=None,
+        )
+
+    container.model_router.provider.generate = absent_npc_generate
+    try:
+        session_response = client.post("/sessions", json=_session_payload(), headers=auth_headers)
+        assert session_response.status_code == 200
+        session_id = session_response.json()["session_id"]
+        before_state = client.get(f"/sessions/{session_id}/state", headers=auth_headers).json()
+        payload = _post_turn_and_wait(
+            client,
+            session_id,
+            auth_headers,
+            f"{absent_npc_name}に話しかける",
         )
         after_state = client.get(f"/sessions/{session_id}/state", headers=auth_headers).json()
     finally:
@@ -441,14 +541,24 @@ def test_harness_rejects_unavailable_location_claim_without_moving_player(client
 
     assert payload["current_location"]["name"] == before_state["current_location"]["name"]
     assert after_state["current_location"]["name"] == before_state["current_location"]["name"]
-    assert payload["location_updates"] == []
-    assert payload["system_message"] == "アクションに失敗しました。SPは返却されました。"
-    assert payload["failure"]["reason"] == "repair_failed"
+    assert payload.get("system_message") is None
+    assert payload.get("failure") is None
+    assert payload.get("refund_ledger_id") is None
 
     with container.session_factory() as db:
         turn = db.get(Turn, payload["turn_id"])
         memories = db.execute(select(Memory).where(Memory.source_event_id == payload["event_id"])).scalars().all()
         assert turn is not None
-        assert turn.resolved_output["status"] == "failed"
-        assert turn.resolved_output["rejected_claims"]
-        assert all("番人" not in memory.text for memory in memories)
+        assert turn.resolved_output["status"] == "resolved"
+        assert turn.resolved_output["used_fallback"] is True
+        assert turn.resolved_output["rejected_claims"] == []
+        # The absent NPC is named as absent in the fallback narrative, not present.
+        assert absent_npc_name in turn.resolved_output["narrative"]
+        assert "見当たらない" in turn.resolved_output["narrative"]
+        # The hallucinated NPC dialogue is never materialized into canonical memory.
+        assert all("裁定の記憶" not in memory.text for memory in memories)
+        event = db.get(Event, payload["event_id"])
+        assert event is not None
+        fallback = event.payload["deterministic_fallback"]
+        assert fallback["reason"] == "consistency_failed"
+        assert any(item.get("claim") == absent_npc_name for item in fallback["rejected_claims"])


### PR DESCRIPTION
Closes #5

## 背景
整合性ハーネスは幻覚(到達不能な場所・非在席NPC)を正しく検出するが、却下後の優雅なフォールバックが無く、repair が同じ不可達先を再幻覚するため `repair_failed` でターン全体が失敗し、同一テキストの再試行で成否が揺れていた(I3)。

## 対応(方針: フォールバックは成功扱い・SP消費 / 発動は整合性却下のみ)

### A. リペアの再幻覚を予防
- `prompts/session/turn_resolution_repair.yaml`: 却下された場所/人物名の**再出力を禁止**する HARD CONSTRAINT を追加。移動先=`visible_exits`・在席者=`visible_people`・現在地=`current_location` のみに限定し、却下対象へ黙って代入せず現在地で完結させ、到達不能を物語で示すよう明示。
- `backend/app/modules/session/service.py`: repair 時の `validation_feedback` を指示的に強化(`Do NOT name '<claim>' again ...`)。

### B. リペア後も却下が残るとき決定論フォールバック
- `backend/app/modules/gm_council/service.py`: `fallback_public_turn()` を新設(死蔵だった `_public_turn_fallback_payload` を活用)。却下クレームを渡して**不可達/非在席を物語で明示**しつつ、現在地クレームのみを出してハーネスをクリーン通過させる。
- `service.py`: repair 後再却下時のハードフェイルを、決定論フォールバックで成功経路へ合流する処理に置換。`turn.resolved` 扱い(SP 消費)・プレイヤー移動なし・幻覚の正史化なし。元の却下クレームは `event_payload.deterministic_fallback` に監査記録し `used_fallback=True` を設定。
- スキーマ/プロバイダ障害(repair が有効出力を出せない場合)は従来通り `repair_failed` + SP 返金を維持。

## テスト
- `repair_failed` を期待していた既存2件をフォールバック成功期待へ更新(1件は `..._falls_back_without_moving_player` へ改名)。
- 非在席NPCの再幻覚→フォールバック回帰テスト `test_harness_repeated_absent_npc_hallucination_falls_back_in_place` を追加。
- 結果: engine **218 passed / 1 skipped**、packs **25 passed**、`turn_resolution_failure_injection` eval **3/3 passed**(council 直叩きの `repair_failed` 経路は不変を確認)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)