### PR TITLE
fix(session): 非同席指名NPCの無言差し替えを防止

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -404,3 +404,5 @@ cypress/videos/
 
 .codegraph
 AGENTS.local.md
+
+.kilo/

--- a/backend/app/modules/gm_council/service.py
+++ b/backend/app/modules/gm_council/service.py
@@ -1391,6 +1391,7 @@ class GMCouncilService:
                         "confidence": 0.7,
                     }
                 ],
+                "addressed_people": [],
                 "suggested_actions": suggestions,
                 "consequence_summary": f"{input_text}が現在の場面に反映された。",
                 "consequence_tags": normalize_consequence_tags(infer_world_tags(input_text)),
@@ -1443,6 +1444,7 @@ class GMCouncilService:
                 "language_context": public_payload.language_context,
                 "public_claims": [item.model_dump() for item in public_payload.public_claims],
                 "present_people": public_payload.present_people,
+                "addressed_people": public_payload.addressed_people,
                 "visible_items": public_payload.visible_items,
                 "used_item_names": public_payload.used_item_names,
                 "normalization_warnings": public_payload.normalization_warnings,

--- a/backend/app/modules/llm_harness/service.py
+++ b/backend/app/modules/llm_harness/service.py
@@ -326,7 +326,7 @@ class PublicClaimDraft(BaseModel):
     kind: Literal["location", "actor", "item", "quest", "fact"]
     surface_text: str = Field(min_length=1)
     language: str = "unknown"
-    role: Literal["current_location", "present", "mentioned", "used", "destination", "offered"] = "mentioned"
+    role: Literal["current_location", "present", "addressed", "mentioned", "used", "destination", "offered"] = "mentioned"
     key_candidate: str | None = None
     confidence: float | None = Field(default=None, ge=0.0, le=1.0)
 
@@ -349,7 +349,7 @@ class PublicClaimDraft(BaseModel):
             kind = "actor"
         normalized["kind"] = kind if kind in {"location", "actor", "item", "quest", "fact"} else "fact"
         role = str(normalized.get("role") or "").strip().lower()
-        normalized["role"] = role if role in {"current_location", "present", "mentioned", "used", "destination", "offered"} else "mentioned"
+        normalized["role"] = role if role in {"current_location", "present", "addressed", "mentioned", "used", "destination", "offered"} else "mentioned"
         normalized["key_candidate"] = _first_non_empty_text(
             normalized.get("key_candidate"),
             normalized.get("canonical_key_candidate"),
@@ -468,6 +468,7 @@ class PublicGmTurnPayload(BaseModel):
     language_context: dict[str, Any] = Field(default_factory=dict)
     public_claims: list[PublicClaimDraft] = Field(default_factory=list)
     present_people: list[str] = Field(default_factory=list)
+    addressed_people: list[str] = Field(default_factory=list)
     visible_items: list[str] = Field(default_factory=list)
     used_item_names: list[str] = Field(default_factory=list)
     known_facts: list[str] = Field(default_factory=list)
@@ -558,6 +559,17 @@ class PublicGmTurnPayload(BaseModel):
             text = str(item).strip()
             if text:
                 present_people.append(text)
+        addressed_people: list[str] = []
+        for item in normalized.get("addressed_people") or []:
+            if isinstance(item, dict):
+                name = _first_non_empty_text(item.get("name"), item.get("display_name"), item.get("surface_text"))
+                if name:
+                    addressed_people.append(name)
+                    warnings.append("addressed_people object was normalized to name")
+                continue
+            text = str(item).strip()
+            if text:
+                addressed_people.append(text)
         visible_items: list[str] = []
         for item in normalized.get("visible_items") or []:
             if isinstance(item, dict):
@@ -570,6 +582,7 @@ class PublicGmTurnPayload(BaseModel):
             if text:
                 visible_items.append(text)
         normalized["present_people"] = present_people
+        normalized["addressed_people"] = addressed_people
         normalized["visible_items"] = visible_items
         normalized["used_item_names"] = [str(item).strip() for item in normalized.get("used_item_names") or [] if str(item).strip()]
         normalized["known_facts"] = [str(item).strip() for item in normalized.get("known_facts") or [] if str(item).strip()]
@@ -927,6 +940,7 @@ class StubModelProvider(BaseModelProvider):
                 }
             ],
             "present_people": [name for name in visible_people if name],
+            "addressed_people": [],
             "visible_items": [name for name in visible_items if name],
             "used_item_names": used_item_names,
             "known_facts": [],

--- a/backend/app/modules/session/service.py
+++ b/backend/app/modules/session/service.py
@@ -30,7 +30,7 @@ from app.models.entities import (
     new_id,
 )
 from app.modules.world_pack.service import normalize_language_tag, resolve_world_pack
-from app.modules.world_state.ambient import list_local_figures
+from app.modules.world_state.ambient import list_local_figures, list_npc_locations
 from app.modules.actor.service import (
     ensure_relationship,
     get_player_profile,
@@ -1334,6 +1334,85 @@ def _name_matches_claim(name: str, claim: str) -> bool:
     return name == claim or name in claim or claim in name
 
 
+def _public_name_matches_claim(name: str, claim: str) -> bool:
+    normalized_name = _normalize_public_claim_text(name)
+    normalized_claim = _normalize_public_claim_text(claim)
+    return _name_matches_claim(name, claim) or _name_matches_claim(normalized_name, normalized_claim)
+
+
+def _public_figure_aliases(figure: dict[str, Any]) -> list[str]:
+    return _unique_public_aliases(
+        [
+            figure.get("source_name"),
+            figure.get("display_name"),
+            figure.get("name"),
+            *_flatten_public_aliases(figure.get("public_aliases")),
+        ]
+    )
+
+
+_ABSENT_PERSON_MARKERS = (
+    "ここにいない",
+    "ここにはいない",
+    "この場にいない",
+    "この場にはいない",
+    "姿は見当たらない",
+    "姿が見当たらない",
+    "見当たらない",
+    "不在",
+    "別の場所",
+    "移動が必要",
+    "会えない",
+    "not here",
+    "not present",
+    "is not here",
+    "isn't here",
+    "absent",
+    "elsewhere",
+    "cannot be reached",
+    "must be reached",
+)
+
+
+def _text_marks_public_person_absent(text: str, person_name: str) -> bool:
+    if not _text_mentions_public_alias(text, [person_name]):
+        return False
+    normalized_text = _normalize_public_claim_text(text)
+    return any(_normalize_public_claim_text(marker) in normalized_text for marker in _ABSENT_PERSON_MARKERS)
+
+
+def _absent_public_npc_candidates(
+    db: Session,
+    *,
+    world_id: str,
+    effective_location_id: str | None,
+) -> list[dict[str, Any]]:
+    candidates = [
+        npc
+        for npc in list_npc_locations(db, world_id)
+        if isinstance(npc, dict)
+        and not (effective_location_id and str(npc.get("location_id") or "") == effective_location_id)
+    ]
+    return _enrich_public_figures_with_aliases(db, world_id=world_id, figures=candidates)
+
+
+def _match_absent_public_npc_claim(
+    candidates: list[dict[str, Any]],
+    *,
+    addressed_name: str,
+) -> dict[str, Any] | None:
+    for npc in candidates:
+        if not isinstance(npc, dict):
+            continue
+        aliases = _public_figure_aliases(npc)
+        if not any(_public_name_matches_claim(alias, addressed_name) for alias in aliases):
+            continue
+        return {
+            "canonical_name": str(npc.get("source_name") or npc.get("display_name") or addressed_name).strip(),
+        }
+    return None
+
+
 def _public_glossary_aliases_for_text(db: Session, world_id: str, text: str) -> list[tuple[str, str]]:
     source = str(text or "").strip()
     if not source:
@@ -2043,30 +2122,67 @@ def _apply_public_ai_gm_harness(
     for item in visible_people_at_effective_location:
         if not isinstance(item, dict):
             continue
-        visible_people_names.extend(
-            _unique_public_aliases(
-                [
-                    item.get("source_name"),
-                    item.get("display_name"),
-                    item.get("name"),
-                    *_flatten_public_aliases(item.get("public_aliases")),
-                ]
-            )
-        )
+        visible_people_names.extend(_public_figure_aliases(item))
     present_people = [str(item).strip() for item in interpreted.get("present_people") or [] if str(item).strip()]
     for claim in public_claims:
         if str(claim.get("kind") or "") == "actor" and str(claim.get("role") or "") == "present":
             surface_text = str(claim.get("surface_text") or "").strip()
             if surface_text:
                 present_people.append(surface_text)
-    for person_name in _unique_public_aliases(present_people):
-        if visible_people_names and any(_name_matches_claim(visible_name, person_name) for visible_name in visible_people_names):
+    normalized_present_people = _unique_public_aliases(present_people)
+    for person_name in normalized_present_people:
+        if visible_people_names and any(_public_name_matches_claim(visible_name, person_name) for visible_name in visible_people_names):
             continue
         rejected.append(
             {
                 "claim_kind": "actor",
                 "claim": person_name,
                 "reason": "The claimed present person is not visible at the canonical turn location.",
+            }
+        )
+
+    addressed_people = [str(item).strip() for item in interpreted.get("addressed_people") or [] if str(item).strip()]
+    for claim in public_claims:
+        if str(claim.get("kind") or "") == "actor" and str(claim.get("role") or "") == "addressed":
+            surface_text = str(claim.get("surface_text") or "").strip()
+            if surface_text:
+                addressed_people.append(surface_text)
+    addressed_absence_evidence = " ".join(
+        [
+            str(payload.narrative or ""),
+            str(payload.npc_reaction or ""),
+            str(payload.consequence_summary or ""),
+            str(interpreted.get("action_interpretation") or ""),
+            str(interpreted.get("current_situation") or ""),
+        ]
+    )
+    absent_npc_candidates: list[dict[str, Any]] | None = None
+    for person_name in _unique_public_aliases(addressed_people):
+        if visible_people_names and any(_public_name_matches_claim(visible_name, person_name) for visible_name in visible_people_names):
+            continue
+        if normalized_present_people and any(_public_name_matches_claim(present_name, person_name) for present_name in normalized_present_people):
+            continue
+        if _text_marks_public_person_absent(addressed_absence_evidence, person_name):
+            continue
+        if absent_npc_candidates is None:
+            absent_npc_candidates = _absent_public_npc_candidates(
+                db,
+                world_id=game_session.world_id,
+                effective_location_id=effective_location_id,
+            )
+        matched_absent_npc = _match_absent_public_npc_claim(
+            absent_npc_candidates,
+            addressed_name=person_name,
+        )
+        if matched_absent_npc is None:
+            continue
+        rejected.append(
+            {
+                "claim_kind": "actor",
+                "claim": person_name,
+                "reason": "addressed_absent",
+                "detail": "The addressed person is a real NPC who is not present at the canonical turn location.",
+                "canonical_name": matched_absent_npc.get("canonical_name"),
             }
         )
 
@@ -2081,6 +2197,57 @@ def _apply_public_ai_gm_harness(
         "travel_summary": travel_summary,
         "effective_location_id": effective_location_id,
     }
+
+
+def _public_validation_feedback_for_rejected_claim(item: dict[str, Any]) -> dict[str, str]:
+    claim = str(item.get("claim") or "")
+    if item.get("reason") == "addressed_absent":
+        message = (
+            f"The addressed person '{claim}' is not present at public_game_context.current_location. "
+            "Do NOT silently substitute a different person who happens to be here. "
+            f"Resolve the turn at the current location and make the narrative state, in-world, that '{claim}' is not here or must be reached elsewhere."
+        ).strip()
+    else:
+        message = (
+            f"{item.get('reason') or 'The output contradicted canonical public state.'} "
+            f"Do NOT name '{claim}' again. It is not reachable/present from the current "
+            "location. Either resolve the turn at public_game_context.current_location, or, if the player "
+            "moves, name only a place in public_game_context.visible_exits."
+        ).strip()
+    return {"reason": "consistency_failed", "claim": claim, "message": message}
+
+
+def _addressed_absent_rejected_claims(rejected_claims: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    claims: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for item in rejected_claims:
+        if not isinstance(item, dict) or item.get("reason") != "addressed_absent":
+            continue
+        claim = str(item.get("claim") or "").strip()
+        key = _normalize_public_claim_text(claim)
+        if not claim or key in seen:
+            continue
+        claims.append(dict(item))
+        seen.add(key)
+    return claims
+
+
+def _consistency_interventions_from_addressed_absent(
+    rejected_claims: list[dict[str, Any]],
+    *,
+    resolved_by: str,
+) -> list[dict[str, Any]]:
+    interventions: list[dict[str, Any]] = []
+    for item in _addressed_absent_rejected_claims(rejected_claims):
+        interventions.append(
+            {
+                "kind": "addressed_absent",
+                "claim": str(item.get("claim") or ""),
+                "canonical_name": str(item.get("canonical_name") or ""),
+                "resolved_by": resolved_by,
+            }
+        )
+    return interventions
 
 
 def _resolve_public_ai_gm_turn_for_session(
@@ -2211,20 +2378,12 @@ def _resolve_public_ai_gm_turn_for_session(
         session_state=session_state,
         apply_changes=False,
     )
+    initial_addressed_absent_claims = _addressed_absent_rejected_claims(dry_run_harness_result["rejected_claims"])
     if dry_run_harness_result["rejected_claims"]:
         repair_resolution = container.council_service.repair_public_turn(
             council_request,
             validation_feedback=[
-                {
-                    "reason": "consistency_failed",
-                    "claim": str(item.get("claim") or ""),
-                    "message": (
-                        f"{item.get('reason') or 'The output contradicted canonical public state.'} "
-                        f"Do NOT name '{item.get('claim') or ''}' again. It is not reachable/present from the current "
-                        "location. Either resolve the turn at public_game_context.current_location, or, if the player "
-                        "moves, name only a place in public_game_context.visible_exits."
-                    ).strip(),
-                }
+                _public_validation_feedback_for_rejected_claim(item)
                 for item in dry_run_harness_result["rejected_claims"]
                 if isinstance(item, dict)
             ],
@@ -2286,6 +2445,10 @@ def _resolve_public_ai_gm_turn_for_session(
             session_state=session_state,
             apply_changes=False,
         )
+        initial_addressed_absent_claims = [
+            *initial_addressed_absent_claims,
+            *_addressed_absent_rejected_claims(dry_run_harness_result["rejected_claims"]),
+        ]
         if dry_run_harness_result["rejected_claims"]:
             # Issue #5 (I3): repair still hallucinated unreachable places / absent
             # people. Rather than failing the whole turn (and re-producing the same
@@ -2320,6 +2483,10 @@ def _resolve_public_ai_gm_turn_for_session(
         apply_changes=True,
     )
     rejected_claims = harness_result["rejected_claims"]
+    consistency_interventions = _consistency_interventions_from_addressed_absent(
+        initial_addressed_absent_claims,
+        resolved_by="fallback" if resolution.deterministic_fallback_used else "repair",
+    )
 
     effective_location_id = player_actor.current_location_id or prepared.location_id
     resolved_world_tags = normalize_world_tags(payload.world_tags)
@@ -2344,6 +2511,7 @@ def _resolve_public_ai_gm_turn_for_session(
             "world_tags": resolved_world_tags,
             "accepted_state_changes": harness_result["accepted_state_changes"],
             "rejected_claims": rejected_claims,
+            "consistency_interventions": consistency_interventions,
             "quest_updates": state_updates["quest_updates"],
             "faction_updates": state_updates["faction_updates"],
             "inventory_updates": state_updates["inventory_updates"],
@@ -2588,6 +2756,7 @@ def _resolve_public_ai_gm_turn_for_session(
         "location_updates": harness_result["location_updates"],
         "accepted_state_changes": harness_result["accepted_state_changes"],
         "rejected_claims": rejected_claims,
+        "consistency_interventions": consistency_interventions,
         "shared_action_tag": shared_result.action_tag,
         "shared_consequence_updates": shared_payload,
         "council_trace": [

--- a/documents/adr/ADR-004-addressed-person-contract.md
+++ b/documents/adr/ADR-004-addressed-person-contract.md
@@ -1,0 +1,34 @@
+# ADR-004: addressed person contract for public turns
+
+## Status
+
+Accepted
+
+## Context
+
+Public AI GM turns can mention people in several ways. A person may be physically present in the scene, merely mentioned in rumor or memory, or directly targeted by the player's action. Previously the public turn contract exposed `present_people` and actor claims with `role=present` or `role=mentioned`, but did not distinguish the literal person the player tried to address.
+
+This allowed a consistency failure: when the player addressed a real NPC who was not at the canonical current location, the AI GM could silently substitute a different visible NPC. The substituted NPC was valid as `present`, so the deterministic harness had no rejected claim to repair or audit.
+
+## Decision
+
+Public GM turn payloads include `addressed_people`, a list of person names that the exact `player_action_text` tries to address, ask, meet, visit, call to, or otherwise contact. Actor public claims may use `role=addressed`.
+
+The roles are interpreted as follows:
+
+- `present`: the person is physically present in the resolved scene.
+- `addressed`: the person is the literal contact target of the player's action, whether or not they are present.
+- `mentioned`: the person is only referenced through rumor, memory, background, or indirect narration.
+
+The AI GM judges whether a name is addressed or merely mentioned from public context and the exact player text. Deterministic code does not infer contact intent from language markers. Deterministic code only validates the resulting public claims against canonical state.
+
+When an addressed person is a real NPC but is not at the canonical resolved location, the consistency harness rejects silent substitution with `reason=addressed_absent`. Repair must resolve at the current location, keep the absent person out of `present_people`, and state in narrative that the addressed person is not here or must be reached elsewhere. If repair still contradicts canonical state, deterministic fallback resolves the turn in place and names the person as absent.
+
+The canonical source for NPC location is PostgreSQL (`actors.current_location_id`). Graph stores are projections rebuilt from PostgreSQL and are not required by synchronous turn validation.
+
+## Consequences
+
+- Non-present addressed NPCs are handled consistently instead of being silently replaced by visible NPCs.
+- Rumor and memory references remain valid when marked `mentioned`.
+- Successful turns can audit `addressed_absent` interventions even when final `rejected_claims` are empty after repair or fallback.
+- The public contract changes without restoring hidden action metadata or legacy `/turns` payloads.

--- a/prompts/session/turn_resolution.yaml
+++ b/prompts/session/turn_resolution.yaml
@@ -24,6 +24,8 @@ instructions: |
   - Do not quote player_action_text as a mechanical sentence. Restate the attempted action in natural prose.
   - current_location_name must be exactly one public place name: either public_game_context.current_location.name, one visible_exits[].destination_name, or a public alias from aliases_by_language. Do not combine a place with an object, fact, quest, slash-separated phrase, or target of investigation.
   - Return public_claims for important public names you used. Each claim may include kind, surface_text, language, role, optional key_candidate, and confidence. key_candidate is only your guess; the runtime harness will ignore it unless surface_text also matches public state.
+  - Put any person the exact player_action_text tries to address, ask, meet, visit, call to, or otherwise contact in addressed_people exactly as the target is written, whether or not that person is present. Mark that actor claim role as addressed. Do not silently replace an addressed person with a different visible person. If the addressed person is not present, resolve at the current location and make the absence or need to reach them clear in narrative.
+  - Use actor role present only for people treated as physically present in this scene. Use actor role mentioned for names that appear only in rumor, memory, background, or indirect reference.
   - Write all player-facing result content in narrative. Do not create separate "reaction" or "change" sections.
   - If the player attempts to move to a visible exit, align narrative, current_situation, current_location_name, public_claims, present_people, visible_items, and suggested_actions with the arrival situation at that destination.
   - If the move is not supported by visible exits, keep narrative, current_situation, public_claims, present_people, visible_items, and suggested_actions grounded in the current_location and visible_people/items only.
@@ -47,12 +49,13 @@ instructions: |
         "kind": "location" | "actor" | "item" | "quest" | "fact",
         "surface_text": string,
         "language": BCP-47 or "unknown",
-        "role": "current_location" | "present" | "mentioned" | "used" | "destination" | "offered",
+        "role": "current_location" | "present" | "addressed" | "mentioned" | "used" | "destination" | "offered",
         "key_candidate": string?,
         "confidence": number?
       }
     ],
     "present_people": string[],
+    "addressed_people": string[],
     "visible_items": string[],
     "used_item_names": string[],
     "known_facts": string[],

--- a/prompts/session/turn_resolution_repair.yaml
+++ b/prompts/session/turn_resolution_repair.yaml
@@ -18,7 +18,8 @@ instructions: |
   - Treat player_action_text as the only player action.
   - Treat public_game_context as player-visible state, not hidden control data.
   - validation_feedback contains only public reasons the previous output could not be used. Fix those problems.
-  - HARD CONSTRAINT: Any place or person named in validation_feedback as not reachable or not present is FORBIDDEN. Do not name it again anywhere (narrative, current_situation, current_location_name, public_claims, present_people, suggested_actions). Re-using a rejected name is the most common repair failure; never do it.
+  - HARD CONSTRAINT: Any place or person named in validation_feedback as not reachable or falsely present is FORBIDDEN as a present person or current/destination place. Do not put it in current_location_name, present_people, visible_items, or a public_claim with role present/current_location/destination.
+  - If validation_feedback says an addressed person is not present, keep that person out of present_people. Do not silently substitute a different visible person. Resolve at public_game_context.current_location and make the narrative state, in-world, that the addressed person is not here or must be reached elsewhere.
   - The only places you may move to are entries of public_game_context.visible_exits. The only people you may treat as present are public_game_context.visible_people. The only canonical current place is public_game_context.current_location. Anything outside these sets does not exist for this turn.
   - If the player's action targeted a place or person that is forbidden by validation_feedback, do not silently substitute a different destination or person. Instead resolve the turn at public_game_context.current_location and let the narrative make clear, in-world, that the targeted place/person is not reachable or present from here right now.
   - Never assume hidden ids, target keys, route keys, choice ids, item ids, quest assignment ids, backend action types, or DB keys.
@@ -29,13 +30,13 @@ instructions: |
   - If movement is not supported, keep all people/items/location claims grounded in public_game_context.current_location and public_game_context.visible_people only.
   - suggested_actions must be objects with label, summary, and optional risk_hint. They must be natural public text only and must reflect the repaired current situation.
   - public_claim.kind allowed values: location, actor, item, quest, fact.
-  - public_claim.role allowed values: current_location, present, mentioned, used, destination, offered.
+  - public_claim.role allowed values: current_location, present, addressed, mentioned, used, destination, offered.
   - Output in public_game_context.language_context.output_language_requested.
 
   Return JSON matching turn_resolution_v2:
   action_interpretation, narrative, current_situation,
   optional current_location_name, language_context, public_claims, present_people,
-  visible_items, used_item_names, known_facts, suggested_actions,
+  addressed_people, visible_items, used_item_names, known_facts, suggested_actions,
   optional internal_summary, consequence_tags, world_tags, shared_action_tag,
   state_drafts, branch_signals, outcome_band, scene_tone, scene_move,
   scene_pressure, memories.

--- a/tests/backend/engine/test_public_ai_gm_contract.py
+++ b/tests/backend/engine/test_public_ai_gm_contract.py
@@ -584,3 +584,345 @@ def test_harness_repeated_absent_npc_hallucination_falls_back_in_place(client, c
         fallback = event.payload["deterministic_fallback"]
         assert fallback["reason"] == "consistency_failed"
         assert any(item.get("claim") == absent_npc_name for item in fallback["rejected_claims"])
+
+
+def test_addressed_absent_npc_repair_can_resolve_with_absence_notice(client, container, auth_headers):
+    original_generate = container.model_router.provider.generate
+    captured: dict[str, str] = {}
+
+    def repaired_address_generate(**kwargs):
+        prompt = kwargs["prompt"]
+        if prompt.prompt_id not in {"session.turn_resolution", "session.turn_resolution_repair"}:
+            return original_generate(**kwargs)
+        public_context = kwargs["input_payload"]["public_game_context"]
+        current_location = public_context["current_location"]["name"]
+        substitute_person = public_context["visible_people"][0]["name"]
+        target_person = next(
+            person["name"]
+            for route in public_context["visible_exits"]
+            for person in route.get("arrival_people") or []
+        )
+        captured["target"] = target_person
+        captured["substitute"] = substitute_person
+        if prompt.prompt_id == "session.turn_resolution_repair":
+            return ProviderResponse(
+                raw_output={
+                    "action_interpretation": f"ヌートは{target_person}に尋ねようとしたが、この場にはいないことを確認する。",
+                    "narrative": f"{target_person}の姿は、この場には見当たらない。{current_location}で確認できる範囲では、会うには別の場所へ向かう必要がある。",
+                    "npc_reaction": "案内役は、現在地で確認できることだけを整理する。",
+                    "current_situation": f"{current_location}では、指名した人物は同席していない。",
+                    "current_location_name": current_location,
+                    "suggested_actions": [
+                        {"label": "行き先を確認する", "summary": "見えている出口から会いに行けるか確かめる。"},
+                        {"label": "この場で聞き込みを続ける", "summary": "現在地で得られる公開情報だけを集める。"},
+                    ],
+                    "consequence_summary": f"{target_person}はこの場にはいないと確認された。",
+                    "world_tags": ["investigate"],
+                    "consequence_tags": ["careful_observation"],
+                    "scene_tone": "measured",
+                    "scene_move": "deepen",
+                    "scene_pressure": "medium",
+                    "memories": [{"scope": "world", "text": f"{target_person}は現在地にいないと確認された。", "salience": 0.7}],
+                    "language_context": {
+                        "pack_source_language": "en",
+                        "play_language": "ja",
+                        "output_language_requested": "ja",
+                    },
+                    "present_people": [],
+                    "addressed_people": [target_person],
+                    "public_claims": [
+                        {"kind": "actor", "surface_text": target_person, "language": "ja", "role": "addressed"},
+                    ],
+                },
+                provider_name="test",
+                provider_response_id=None,
+            )
+        return ProviderResponse(
+            raw_output={
+                "action_interpretation": f"ヌートは{substitute_person}に街道の霧について尋ねる。",
+                "narrative": f"{substitute_person}は帳簿を閉じ、街道の霧について答えた。",
+                "npc_reaction": f"{substitute_person}は今見える範囲の話だけを返した。",
+                "current_situation": f"{current_location}では{substitute_person}が近くにいる。",
+                "current_location_name": current_location,
+                "suggested_actions": [
+                    {"label": "この場で確認する", "summary": "現在地で見える情報だけを整理する。"},
+                    {"label": "出口を確認する", "summary": "会いたい人物のいる場所へ行けるか確かめる。"},
+                ],
+                "consequence_summary": f"{substitute_person}が街道の霧について答えた。",
+                "world_tags": ["investigate"],
+                "consequence_tags": ["careful_observation"],
+                "scene_tone": "measured",
+                "scene_move": "deepen",
+                "scene_pressure": "medium",
+                "memories": [{"scope": "world", "text": f"{substitute_person}が{target_person}の代わりに応答した。", "salience": 0.7}],
+                "language_context": {
+                    "pack_source_language": "en",
+                    "play_language": "ja",
+                    "output_language_requested": "ja",
+                },
+                "present_people": [substitute_person],
+                "addressed_people": [target_person],
+                "public_claims": [
+                    {"kind": "actor", "surface_text": target_person, "language": "ja", "role": "addressed"},
+                    {"kind": "actor", "surface_text": substitute_person, "language": "ja", "role": "present"},
+                ],
+            },
+            provider_name="test",
+            provider_response_id=None,
+        )
+
+    container.model_router.provider.generate = repaired_address_generate
+    try:
+        session_response = client.post("/sessions", json=_session_payload(), headers=auth_headers)
+        assert session_response.status_code == 200
+        session_id = session_response.json()["session_id"]
+        payload = _post_turn_and_wait(client, session_id, auth_headers, "万象図書館の歴史家AIに街道の霧について尋ねる")
+    finally:
+        container.model_router.provider.generate = original_generate
+
+    target_person = captured["target"]
+    substitute_person = captured["substitute"]
+    with container.session_factory() as db:
+        turn = db.get(Turn, payload["turn_id"])
+        memories = db.execute(select(Memory).where(Memory.source_event_id == payload["event_id"])).scalars().all()
+        event = db.get(Event, payload["event_id"])
+        assert turn is not None
+        assert event is not None
+        assert turn.resolved_output["status"] == "resolved"
+        assert turn.resolved_output["used_fallback"] is False
+        assert turn.resolved_output["rejected_claims"] == []
+        assert target_person in turn.resolved_output["narrative"]
+        assert "見当たらない" in turn.resolved_output["narrative"]
+        assert all("代わりに応答" not in memory.text for memory in memories)
+        assert "deterministic_fallback" not in event.payload
+        assert any(
+            item["kind"] == "addressed_absent" and item["claim"] == target_person and item["resolved_by"] == "repair"
+            for item in turn.resolved_output["consistency_interventions"]
+        )
+        assert substitute_person not in turn.resolved_output["narrative"]
+
+
+def test_addressed_absent_npc_substitution_records_intervention_and_falls_back(client, container, auth_headers):
+    original_generate = container.model_router.provider.generate
+    captured: dict[str, str] = {}
+
+    def substituted_address_generate(**kwargs):
+        prompt = kwargs["prompt"]
+        if prompt.prompt_id not in {"session.turn_resolution", "session.turn_resolution_repair"}:
+            return original_generate(**kwargs)
+        public_context = kwargs["input_payload"]["public_game_context"]
+        current_location = public_context["current_location"]["name"]
+        substitute_person = public_context["visible_people"][0]["name"]
+        target_person = next(
+            person["name"]
+            for route in public_context["visible_exits"]
+            for person in route.get("arrival_people") or []
+        )
+        captured["target"] = target_person
+        captured["substitute"] = substitute_person
+        return ProviderResponse(
+            raw_output={
+                "action_interpretation": f"ヌートは{substitute_person}に街道の霧について尋ねる。",
+                "narrative": f"{substitute_person}は帳簿を閉じ、街道の霧について答えた。",
+                "npc_reaction": f"{substitute_person}は今見える範囲の話だけを返した。",
+                "current_situation": f"{current_location}では{substitute_person}が近くにいる。",
+                "current_location_name": current_location,
+                "suggested_actions": [
+                    {"label": "この場で確認する", "summary": "現在地で見える情報だけを整理する。"},
+                    {"label": "出口を確認する", "summary": "会いたい人物のいる場所へ行けるか確かめる。"},
+                ],
+                "consequence_summary": f"{substitute_person}が街道の霧について答えた。",
+                "world_tags": ["investigate"],
+                "consequence_tags": ["careful_observation"],
+                "scene_tone": "measured",
+                "scene_move": "deepen",
+                "scene_pressure": "medium",
+                "memories": [{"scope": "world", "text": f"{substitute_person}が{target_person}の代わりに応答した。", "salience": 0.7}],
+                "language_context": {
+                    "pack_source_language": "en",
+                    "play_language": "ja",
+                    "output_language_requested": "ja",
+                },
+                "present_people": [substitute_person],
+                "addressed_people": [target_person],
+                "public_claims": [
+                    {"kind": "actor", "surface_text": target_person, "language": "ja", "role": "addressed"},
+                    {"kind": "actor", "surface_text": substitute_person, "language": "ja", "role": "present"},
+                ],
+            },
+            provider_name="test",
+            provider_response_id=None,
+        )
+
+    container.model_router.provider.generate = substituted_address_generate
+    try:
+        session_response = client.post("/sessions", json=_session_payload(), headers=auth_headers)
+        assert session_response.status_code == 200
+        session_id = session_response.json()["session_id"]
+        before_state = client.get(f"/sessions/{session_id}/state", headers=auth_headers).json()
+        payload = _post_turn_and_wait(client, session_id, auth_headers, f"{captured.get('target') or '万象図書館の歴史家AI'}に街道の霧について尋ねる")
+        after_state = client.get(f"/sessions/{session_id}/state", headers=auth_headers).json()
+    finally:
+        container.model_router.provider.generate = original_generate
+
+    target_person = captured["target"]
+    substitute_person = captured["substitute"]
+    assert payload["current_location"]["name"] == before_state["current_location"]["name"]
+    assert after_state["current_location"]["name"] == before_state["current_location"]["name"]
+    assert payload.get("system_message") is None
+    assert payload.get("failure") is None
+    assert payload.get("refund_ledger_id") is None
+
+    with container.session_factory() as db:
+        turn = db.get(Turn, payload["turn_id"])
+        memories = db.execute(select(Memory).where(Memory.source_event_id == payload["event_id"])).scalars().all()
+        event = db.get(Event, payload["event_id"])
+        assert turn is not None
+        assert event is not None
+        assert turn.resolved_output["status"] == "resolved"
+        assert turn.resolved_output["used_fallback"] is True
+        assert turn.resolved_output["rejected_claims"] == []
+        assert target_person in turn.resolved_output["narrative"]
+        assert "見当たらない" in turn.resolved_output["narrative"]
+        assert all("代わりに応答" not in memory.text for memory in memories)
+        interventions = turn.resolved_output["consistency_interventions"]
+        assert any(item["kind"] == "addressed_absent" and item["claim"] == target_person and item["resolved_by"] == "fallback" for item in interventions)
+        fallback = event.payload["deterministic_fallback"]
+        assert any(
+            item.get("claim") == target_person and item.get("reason") == "addressed_absent"
+            for item in fallback["rejected_claims"]
+        )
+        assert substitute_person not in turn.resolved_output["narrative"] or "見当たらない" in turn.resolved_output["narrative"]
+
+
+def test_absent_npc_mentioned_only_does_not_trigger_addressed_absent(client, container, auth_headers):
+    original_generate = container.model_router.provider.generate
+    captured: dict[str, str] = {}
+
+    def mentioned_generate(**kwargs):
+        prompt = kwargs["prompt"]
+        if prompt.prompt_id != "session.turn_resolution":
+            return original_generate(**kwargs)
+        public_context = kwargs["input_payload"]["public_game_context"]
+        current_location = public_context["current_location"]["name"]
+        visible_person = public_context["visible_people"][0]["name"]
+        mentioned_person = next(
+            person["name"]
+            for route in public_context["visible_exits"]
+            for person in route.get("arrival_people") or []
+        )
+        captured["mentioned"] = mentioned_person
+        return ProviderResponse(
+            raw_output={
+                "action_interpretation": f"ヌートは{mentioned_person}についての噂を思い出す。",
+                "narrative": f"ヌートは{current_location}で、{mentioned_person}に関する噂を整理した。",
+                "npc_reaction": f"{visible_person}は噂を確定情報として扱わないよう促した。",
+                "current_situation": f"{current_location}では記録の確認が続いている。",
+                "current_location_name": current_location,
+                "suggested_actions": [
+                    {"label": "噂の出所を確認する", "summary": "現在地で確認できる情報源を探す。"},
+                    {"label": "別の場所へ向かう", "summary": "見えている出口から手がかりを追う。"},
+                ],
+                "consequence_summary": f"{mentioned_person}は噂として言及された。",
+                "world_tags": ["investigate"],
+                "consequence_tags": ["careful_observation"],
+                "scene_tone": "measured",
+                "scene_move": "deepen",
+                "scene_pressure": "medium",
+                "memories": [{"scope": "world", "text": f"{mentioned_person}についての噂が整理された。", "salience": 0.7}],
+                "language_context": {
+                    "pack_source_language": "en",
+                    "play_language": "ja",
+                    "output_language_requested": "ja",
+                },
+                "present_people": [visible_person],
+                "addressed_people": [],
+                "public_claims": [
+                    {"kind": "actor", "surface_text": mentioned_person, "language": "ja", "role": "mentioned"},
+                    {"kind": "actor", "surface_text": visible_person, "language": "ja", "role": "present"},
+                ],
+            },
+            provider_name="test",
+            provider_response_id=None,
+        )
+
+    container.model_router.provider.generate = mentioned_generate
+    try:
+        session_response = client.post("/sessions", json=_session_payload(), headers=auth_headers)
+        assert session_response.status_code == 200
+        payload = _post_turn_and_wait(client, session_response.json()["session_id"], auth_headers, "別地点の人物についての噂を整理する")
+    finally:
+        container.model_router.provider.generate = original_generate
+
+    with container.session_factory() as db:
+        turn = db.get(Turn, payload["turn_id"])
+        assert turn is not None
+        assert turn.resolved_output["status"] == "resolved"
+        assert turn.resolved_output["used_fallback"] is False
+        assert turn.resolved_output["rejected_claims"] == []
+        assert turn.resolved_output["consistency_interventions"] == []
+        assert captured["mentioned"] in turn.resolved_output["narrative"]
+
+
+def test_present_addressed_npc_passes_without_intervention(client, container, auth_headers):
+    original_generate = container.model_router.provider.generate
+    captured: dict[str, str] = {}
+
+    def present_address_generate(**kwargs):
+        prompt = kwargs["prompt"]
+        if prompt.prompt_id != "session.turn_resolution":
+            return original_generate(**kwargs)
+        public_context = kwargs["input_payload"]["public_game_context"]
+        current_location = public_context["current_location"]["name"]
+        visible_person = public_context["visible_people"][0]["name"]
+        captured["visible"] = visible_person
+        return ProviderResponse(
+            raw_output={
+                "action_interpretation": f"ヌートは{visible_person}に確認を求める。",
+                "narrative": f"ヌートが問いかけると、{visible_person}は現在地で確認できる情報だけを返した。",
+                "npc_reaction": f"{visible_person}は穏やかに頷いた。",
+                "current_situation": f"{current_location}では{visible_person}が同席している。",
+                "current_location_name": current_location,
+                "suggested_actions": [
+                    {"label": "さらに確認する", "summary": "同席者へ公開情報を尋ねる。"},
+                    {"label": "周囲を見回す", "summary": "現在地で見えるものを確認する。"},
+                ],
+                "consequence_summary": f"{visible_person}への問いかけが現在地で解決された。",
+                "world_tags": ["investigate"],
+                "consequence_tags": ["careful_observation"],
+                "scene_tone": "measured",
+                "scene_move": "deepen",
+                "scene_pressure": "medium",
+                "memories": [{"scope": "world", "text": f"{visible_person}が公開情報を返した。", "salience": 0.7}],
+                "language_context": {
+                    "pack_source_language": "en",
+                    "play_language": "ja",
+                    "output_language_requested": "ja",
+                },
+                "present_people": [visible_person],
+                "addressed_people": [visible_person],
+                "public_claims": [
+                    {"kind": "actor", "surface_text": visible_person, "language": "ja", "role": "addressed"},
+                    {"kind": "actor", "surface_text": visible_person, "language": "ja", "role": "present"},
+                ],
+            },
+            provider_name="test",
+            provider_response_id=None,
+        )
+
+    container.model_router.provider.generate = present_address_generate
+    try:
+        session_response = client.post("/sessions", json=_session_payload(), headers=auth_headers)
+        assert session_response.status_code == 200
+        payload = _post_turn_and_wait(client, session_response.json()["session_id"], auth_headers, "同席している案内担当に確認を求める")
+    finally:
+        container.model_router.provider.generate = original_generate
+
+    with container.session_factory() as db:
+        turn = db.get(Turn, payload["turn_id"])
+        assert turn is not None
+        assert turn.resolved_output["status"] == "resolved"
+        assert turn.resolved_output["used_fallback"] is False
+        assert turn.resolved_output["rejected_claims"] == []
+        assert turn.resolved_output["consistency_interventions"] == []
+        assert captured["visible"] in turn.resolved_output["narrative"]


### PR DESCRIPTION
## Summary
- `addressed_people` / actor `role=addressed` を public turn contract に追加
- 非同席の実在NPCが指名されたまま別NPCへ無言差し替えされるケースを `addressed_absent` として検出・repair/fallback・監査記録
- ADR-004 と回帰テストで、repair成功・fallback・mentionedのみ・同席addressed正常系を固定

Closes #7

## Verification
- `PYTHONPATH=backend python -m pytest tests/backend`
- `make scan-v1-terms`