### PR TITLE
fix(session): self-state claims and outcome band

### DIFF
--- a/backend/app/api/routes/turns.py
+++ b/backend/app/api/routes/turns.py
@@ -164,6 +164,7 @@ def _success_response_content(result, world_context: dict[str, object]) -> dict[
         "blocked_state_drafts": result.blocked_state_drafts,
         "location_updates": result.location_updates,
         "entity_updates": result.turn.resolved_output.get("entity_updates", []),
+        "unconfirmed_self_claims": result.turn.resolved_output.get("unconfirmed_self_claims", []),
         "relationship_updates": result.relationship_updates,
         "consequence_updates": result.consequence_updates,
         "scene_updates": result.scene_updates,

--- a/backend/app/modules/gm_council/service.py
+++ b/backend/app/modules/gm_council/service.py
@@ -1011,12 +1011,27 @@ def _public_session_context(session_state: dict[str, Any]) -> dict[str, Any]:
     nearby_routes = [item for item in session_state.get("nearby_routes") or [] if isinstance(item, dict)]
     current_scene = session_state.get("current_scene") if isinstance(session_state.get("current_scene"), dict) else {}
     chapter = session_state.get("chapter") if isinstance(session_state.get("chapter"), dict) else {}
+    skills = [item for item in session_state.get("skills") or [] if isinstance(item, dict)]
+    state_bands = session_state.get("narrative_state_bands") if isinstance(session_state.get("narrative_state_bands"), dict) else {}
     return {
         "language_context": {
             "pack_source_language": source_language,
             "play_language": play_language_code,
             "output_language_requested": play_language_code,
         },
+        "player_condition": {
+            "vitality": _public_text(state_bands.get("vitality")) or "steady",
+            "clarity": _public_text(state_bands.get("clarity")) or "steady",
+            "standing": _public_text(state_bands.get("standing")) or "unknown",
+        },
+        "player_capabilities": [
+            {
+                "title": _public_text(item.get("title")),
+                "summary": _public_text(item.get("summary")),
+            }
+            for item in skills
+            if _public_text(item.get("title"))
+        ][:8],
         "current_location": {
             "name": _display_name_for_language(
                 current_source_name,
@@ -1456,6 +1471,7 @@ class GMCouncilService:
             shared_action_tag=public_payload.shared_action_tag,
             state_drafts=public_payload.state_drafts,
             branch_signals=public_payload.branch_signals,
+            self_state_claims=public_payload.self_state_claims,
             outcome_band=public_payload.outcome_band,
             scene_tone=public_payload.scene_tone,
             scene_move=public_payload.scene_move,

--- a/backend/app/modules/llm_harness/service.py
+++ b/backend/app/modules/llm_harness/service.py
@@ -358,6 +358,40 @@ class PublicClaimDraft(BaseModel):
         return normalized
 
 
+class SelfStateClaimDraft(BaseModel):
+    kind: Literal["vitality", "ability", "other"] = "other"
+    surface_text: str = Field(min_length=1)
+    persistence: Literal["subjective", "canonical"] = "subjective"
+    backing: str | None = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def normalize_live_provider_shape(cls, value: Any) -> Any:
+        if not isinstance(value, dict):
+            return value
+        normalized = dict(value)
+        normalized["surface_text"] = _first_non_empty_text(
+            normalized.get("surface_text"),
+            normalized.get("text"),
+            normalized.get("claim"),
+            normalized.get("summary"),
+        )
+        kind = str(normalized.get("kind") or "").strip().lower()
+        if kind in {"vitality", "health", "hp", "death", "revival", "life"}:
+            kind = "vitality"
+        elif kind in {"ability", "skill", "power", "capability"}:
+            kind = "ability"
+        normalized["kind"] = kind if kind in {"vitality", "ability", "other"} else "other"
+        persistence = str(normalized.get("persistence") or "").strip().lower()
+        if persistence in {"canonical", "canon", "permanent", "persistent"}:
+            persistence = "canonical"
+        else:
+            persistence = "subjective"
+        normalized["persistence"] = persistence
+        normalized["backing"] = _first_non_empty_text(normalized.get("backing"), normalized.get("backing_ref")) or None
+        return normalized
+
+
 class CouncilIntentInterpreterPayload(BaseModel):
     input_mode: Literal["choice", "free_text"]
     canonical_action_kind: Literal["narrative", "use_reward_item", "travel"]
@@ -445,6 +479,7 @@ class TurnResolutionPayload(BaseModel):
     shared_action_tag: SharedWorldActionTag = "none"
     state_drafts: dict[str, Any] = Field(default_factory=dict)
     branch_signals: list[BranchSignal] = Field(default_factory=list)
+    self_state_claims: list[SelfStateClaimDraft] = Field(default_factory=list)
     outcome_band: OutcomeBand = "steady"
     scene_tone: str = Field(min_length=1)
     scene_move: Literal["hold", "deepen", "pivot", "close"] = "hold"
@@ -481,6 +516,7 @@ class PublicGmTurnPayload(BaseModel):
     shared_action_tag: SharedWorldActionTag = "none"
     state_drafts: dict[str, Any] = Field(default_factory=dict)
     branch_signals: list[BranchSignal] = Field(default_factory=list)
+    self_state_claims: list[SelfStateClaimDraft] = Field(default_factory=list)
     outcome_band: OutcomeBand = "steady"
     scene_tone: str = Field(min_length=1)
     scene_move: Literal["hold", "deepen", "pivot", "close"] = "hold"
@@ -623,6 +659,10 @@ class PublicGmTurnPayload(BaseModel):
         if not isinstance(normalized.get("branch_signals"), list):
             normalized["branch_signals"] = []
         normalized["branch_signals"] = normalize_branch_signals([str(item) for item in normalized.get("branch_signals") or []])
+        self_state_claims = normalized.get("self_state_claims")
+        if not isinstance(self_state_claims, list):
+            self_state_claims = []
+        normalized["self_state_claims"] = [item for item in self_state_claims if isinstance(item, dict)]
         normalized["outcome_band"] = str(normalized.get("outcome_band") or "steady")
         if normalized["outcome_band"] not in {"steady", "tangled", "setback"}:
             normalized["outcome_band"] = "steady"

--- a/backend/app/modules/session/service.py
+++ b/backend/app/modules/session/service.py
@@ -1866,6 +1866,69 @@ def _player_facing_metadata_violations(payload: Any) -> list[dict[str, str]]:
     return violations
 
 
+def _self_state_draft_count(state_drafts: Any, key: str) -> int:
+    if not isinstance(state_drafts, dict):
+        return 0
+    raw = state_drafts.get(key)
+    if isinstance(raw, dict):
+        return 1
+    if isinstance(raw, list):
+        return len([item for item in raw if isinstance(item, dict)])
+    return 0
+
+
+def _claim_attr(claim: Any, name: str) -> Any:
+    if isinstance(claim, dict):
+        return claim.get(name)
+    return getattr(claim, name, None)
+
+
+def _unconfirmed_self_state_claims(payload: Any) -> list[dict[str, Any]]:
+    """Reconcile structured AI GM self-state claims against their backing.
+
+    A canonical player self-state change (death, revival, a new power) only
+    enters canonical world fact when it is genuinely backed by a structured
+    change this turn. Death/revival have no canonical mechanism (CharacterSheet
+    HP is not mutated by turns), so they are always subjective. Ability claims
+    require a backing state_drafts.skills entry. Unbacked canonical claims are
+    downgraded to subjective and returned as audit records; the turn still
+    resolves and the narrative is preserved (Issue #8 / I6). This inspects only
+    the structured claim list, never the prose."""
+    claims = getattr(payload, "self_state_claims", None) or []
+    state_drafts = getattr(payload, "state_drafts", None)
+    skill_backing = _self_state_draft_count(state_drafts, "skills")
+    other_backing = (
+        skill_backing
+        + _self_state_draft_count(state_drafts, "acquired_items")
+        + _self_state_draft_count(state_drafts, "known_facts")
+    )
+    unconfirmed: list[dict[str, Any]] = []
+    for claim in claims:
+        if str(_claim_attr(claim, "persistence") or "subjective") != "canonical":
+            continue
+        kind = str(_claim_attr(claim, "kind") or "other")
+        surface_text = str(_claim_attr(claim, "surface_text") or "").strip()
+        if kind == "vitality":
+            backed = False
+            reason = "Player death or revival has no canonical mechanism; recorded as unconfirmed subjective experience."
+        elif kind == "ability":
+            backed = skill_backing > 0
+            reason = "A newly claimed ability had no backing skill state; recorded as unconfirmed subjective experience."
+        else:
+            backed = other_backing > 0
+            reason = "A self-state change had no backing structured state; recorded as unconfirmed subjective experience."
+        if backed:
+            continue
+        unconfirmed.append(
+            {
+                "kind": kind,
+                "claim": surface_text,
+                "reason": reason,
+            }
+        )
+    return unconfirmed
+
+
 def _naturalized_action_attempt(input_text: str) -> str:
     text = " ".join(str(input_text or "").split()).strip("。.")
     if "。" in text:
@@ -2487,6 +2550,7 @@ def _resolve_public_ai_gm_turn_for_session(
         initial_addressed_absent_claims,
         resolved_by="fallback" if resolution.deterministic_fallback_used else "repair",
     )
+    unconfirmed_self_claims = _unconfirmed_self_state_claims(payload)
 
     effective_location_id = player_actor.current_location_id or prepared.location_id
     resolved_world_tags = normalize_world_tags(payload.world_tags)
@@ -2512,6 +2576,7 @@ def _resolve_public_ai_gm_turn_for_session(
             "accepted_state_changes": harness_result["accepted_state_changes"],
             "rejected_claims": rejected_claims,
             "consistency_interventions": consistency_interventions,
+            "unconfirmed_self_claims": unconfirmed_self_claims,
             "quest_updates": state_updates["quest_updates"],
             "faction_updates": state_updates["faction_updates"],
             "inventory_updates": state_updates["inventory_updates"],
@@ -2617,6 +2682,7 @@ def _resolve_public_ai_gm_turn_for_session(
             or fallback_consequence_tags(world_tags=resolved_world_tags, action_kind="narrative", fail_forward=False),
             action_kind="narrative",
             fail_forward=False,
+            model_outcome_band=payload.outcome_band,
         )
         branch_result = BranchPressureEngine.apply_player_turn(
             db,
@@ -2661,18 +2727,26 @@ def _resolve_public_ai_gm_turn_for_session(
         )
 
     with _turn_progress_span("memory_materialization"):
+        # When the AI GM's structured self_state_claims include an unbacked
+        # canonical self-state change (death/revival/new power), do not let that
+        # turn's free-form world memory drafts assert the subjective experience as
+        # canonical world fact (Issue #8 / I6). Deterministic/grounded drafts from
+        # the harness and consequence engine are still materialized.
+        suppress_world_self_claim_memory = bool(unconfirmed_self_claims)
+        player_memory_drafts = [
+            {
+                **draft.model_dump(),
+                "actor_id": guide_npc.id if draft.scope == "actor" else None,
+            }
+            for draft in payload.memories
+            if not (suppress_world_self_claim_memory and draft.scope == "world")
+        ]
         memories = container.memory_service.materialize_memories(
             db,
             world_id=game_session.world_id,
             source_event_id=event.id,
             location_id=effective_location_id,
-            drafts=[
-                {
-                    **draft.model_dump(),
-                    "actor_id": guide_npc.id if draft.scope == "actor" else None,
-                }
-                for draft in payload.memories
-            ]
+            drafts=player_memory_drafts
             + harness_result["memory_drafts"]
             + consequence_result.additional_memory_drafts,
         )
@@ -2757,6 +2831,7 @@ def _resolve_public_ai_gm_turn_for_session(
         "accepted_state_changes": harness_result["accepted_state_changes"],
         "rejected_claims": rejected_claims,
         "consistency_interventions": consistency_interventions,
+        "unconfirmed_self_claims": unconfirmed_self_claims,
         "shared_action_tag": shared_result.action_tag,
         "shared_consequence_updates": shared_payload,
         "council_trace": [
@@ -4886,6 +4961,7 @@ def _build_failed_turn_result(
         },
         "scene_tone": scene_tone_for_band("setback"),
         "outcome_band": "setback",
+        "failure_band": True,
         **(failure_payload or {}),
     }
     failure_event = Event(

--- a/backend/app/modules/world_state/consequence.py
+++ b/backend/app/modules/world_state/consequence.py
@@ -63,6 +63,26 @@ def relationship_band(strength: float) -> RelationshipBand:
     return "trusted"
 
 
+_OUTCOME_BAND_SEVERITY: dict[str, int] = {"steady": 0, "tangled": 1, "setback": 2}
+
+
+def max_outcome_band(*bands: str | None) -> OutcomeBand:
+    """Return the most severe of the supplied outcome bands (steady < tangled < setback).
+
+    The deterministic consequence engine derives a band from social tags, while the
+    AI GM judges the narrative stakes. Reconciling by max severity keeps both the
+    AI GM's narrative-risk read (Issue #8 / I6) and the engine's tag-driven setbacks.
+    """
+    best = "steady"
+    best_rank = 0
+    for band in bands:
+        rank = _OUTCOME_BAND_SEVERITY.get(str(band or ""), 0)
+        if rank > best_rank:
+            best_rank = rank
+            best = str(band)
+    return best  # type: ignore[return-value]
+
+
 def scene_tone_for_band(outcome_band: OutcomeBand) -> str:
     if outcome_band == "steady":
         return "steady"

--- a/backend/app/modules/world_state/service.py
+++ b/backend/app/modules/world_state/service.py
@@ -78,6 +78,7 @@ from app.modules.world_state.consequence import (
     ThreadStatus,
     ThreadType,
     fallback_consequence_tags,
+    max_outcome_band,
     normalize_consequence_tags,
     relationship_band,
     relationship_summary,
@@ -4294,6 +4295,7 @@ def apply_consequence_updates(
     consequence_tags: list[str] | None,
     action_kind: str,
     fail_forward: bool = False,
+    model_outcome_band: str | None = None,
 ) -> ConsequenceApplicationOutcome:
     relationship_updates: list[dict[str, Any]] = []
     consequence_updates: list[dict[str, Any]] = []
@@ -4444,13 +4446,15 @@ def apply_consequence_updates(
         )
 
     db.flush()
+    reconciled_band = max_outcome_band(outcome.outcome_band, model_outcome_band)
+    reconciled_tone = outcome.scene_tone if reconciled_band == outcome.outcome_band else scene_tone_for_band(reconciled_band)
     return ConsequenceApplicationOutcome(
         relationship_updates=relationship_updates,
         consequence_updates=consequence_updates,
         faction_updates=faction_updates,
         additional_memory_drafts=additional_memory_drafts,
-        outcome_band=outcome.outcome_band,
-        scene_tone=outcome.scene_tone,
+        outcome_band=reconciled_band,
+        scene_tone=reconciled_tone,
         consequence_summary=consequence_summary_text,
     )
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -527,6 +527,11 @@ export type TurnResponse = {
   }>;
   recent_world_beats: string[];
   recent_offstage_beats: string[];
+  unconfirmed_self_claims?: Array<{
+    kind: string;
+    claim: string;
+    reason: string;
+  }>;
   crossroads_summary: string;
   idle_updates: Array<{
     event_id: string;

--- a/prompts/session/turn_resolution.yaml
+++ b/prompts/session/turn_resolution.yaml
@@ -30,6 +30,11 @@ instructions: |
   - If the player attempts to move to a visible exit, align narrative, current_situation, current_location_name, public_claims, present_people, visible_items, and suggested_actions with the arrival situation at that destination.
   - If the move is not supported by visible exits, keep narrative, current_situation, public_claims, present_people, visible_items, and suggested_actions grounded in the current_location and visible_people/items only.
   - If the player attempts movement, item use, quest progress, or authority changes, describe only what follows from public facts available in context. The runtime harness will decide which claims can enter canonical state.
+  - public_game_context.player_condition (vitality/clarity/standing bands) and player_capabilities (known skills) are the player's current canonical self-state. Treat them as the ground truth about whether the player is alive, hurt, and what they can already do.
+  - The player cannot unilaterally make their own death, revival, or acquisition of a new power into canonical world fact. Such self-state changes only become canonical when backed by a structured change in this turn (for example a state_drafts.skills entry for a newly learned capability). Death and revival have no canonical mechanism and are always subjective.
+  - You may still narrate a subjective self-state experience freely (pain, a sense of dying, a feeling of new power); narrative breadth is allowed. What is constrained is only whether it is recorded as canonical world fact.
+  - Report every self-state change you narrate in self_state_claims. Set persistence to "canonical" only when the change is genuinely backed by player_condition, player_capabilities, known_facts, or a structured draft in this turn; otherwise set persistence to "subjective". Do not contradict player_condition/player_capabilities with a canonical claim.
+  - outcome_band must reflect the narrative stakes of this turn (steady when calm/safe, tangled when complicated/uncertain, setback when a real reversal or danger lands). Do not default to steady for tense, dangerous, or failing situations, and do not tie outcome_band to whether the turn merely succeeded mechanically.
   - Return next suggested_actions as public natural-language actions only. Do not include ids, target fields, action_kind fields, effect fields, or route keys.
   - suggested_actions must reflect the result and current situation after this turn. Do not simply repeat public_game_context.visible_opportunities; if little changed, offer follow-up confirmation, a local inquiry, or a visible exit/action that fits the current situation.
   - Optional quest_offer/followup_quest_offer may be emitted only for a future-facing independent playable objective with player attention basis, current location/shared-world basis, uncertainty, and a first actionable step. Do not emit one for a single next action, broad browsing, vague exploration, a duplicate live quest, the latest result summary, or a conclusion that reveals the final cause or solution.
@@ -59,6 +64,14 @@ instructions: |
     "visible_items": string[],
     "used_item_names": string[],
     "known_facts": string[],
+    "self_state_claims": [
+      {
+        "kind": "vitality" | "ability" | "other",
+        "surface_text": string,
+        "persistence": "subjective" | "canonical",
+        "backing": string?
+      }
+    ],
     "suggested_actions": [{"label": string, "summary": string, "risk_hint": string?}],
     "internal_summary": string?,
     "consequence_tags": string[],

--- a/prompts/session/turn_resolution_repair.yaml
+++ b/prompts/session/turn_resolution_repair.yaml
@@ -31,6 +31,8 @@ instructions: |
   - suggested_actions must be objects with label, summary, and optional risk_hint. They must be natural public text only and must reflect the repaired current situation.
   - public_claim.kind allowed values: location, actor, item, quest, fact.
   - public_claim.role allowed values: current_location, present, addressed, mentioned, used, destination, offered.
+  - public_game_context.player_condition and player_capabilities are the player's current canonical self-state. The player cannot unilaterally make their own death, revival, or new power into canonical world fact; such changes are canonical only when backed by a structured change this turn. Death and revival are always subjective. Narrate subjective self-state freely, but report each self-state change in self_state_claims with persistence "subjective" unless genuinely backed.
+  - outcome_band must reflect the narrative stakes (steady/tangled/setback), not whether the turn merely succeeded mechanically.
   - Output in public_game_context.language_context.output_language_requested.
 
   Return JSON matching turn_resolution_v2:
@@ -38,5 +40,5 @@ instructions: |
   optional current_location_name, language_context, public_claims, present_people,
   addressed_people, visible_items, used_item_names, known_facts, suggested_actions,
   optional internal_summary, consequence_tags, world_tags, shared_action_tag,
-  state_drafts, branch_signals, outcome_band, scene_tone, scene_move,
+  state_drafts, branch_signals, self_state_claims, outcome_band, scene_tone, scene_move,
   scene_pressure, memories.

--- a/tests/backend/engine/test_api_contracts.py
+++ b/tests/backend/engine/test_api_contracts.py
@@ -1004,6 +1004,7 @@ def test_session_and_turn_contract_and_websocket_event_order(client, auth_header
             "shared_action_tag",
             "shared_consequence_updates",
             "entity_updates",
+            "unconfirmed_self_claims",
         }
         assert turn_payload["shared_action_tag"] == "none"
         assert turn_payload["shared_consequence_updates"]["shared_action_tag"] == "none"

--- a/tests/backend/engine/test_public_ai_gm_contract.py
+++ b/tests/backend/engine/test_public_ai_gm_contract.py
@@ -926,3 +926,183 @@ def test_present_addressed_npc_passes_without_intervention(client, container, au
         assert turn.resolved_output["rejected_claims"] == []
         assert turn.resolved_output["consistency_interventions"] == []
         assert captured["visible"] in turn.resolved_output["narrative"]
+
+
+def _self_state_turn_generate(original_generate, *, self_state_claims, state_drafts=None, outcome_band="steady", scene_pressure="medium", world_memory_text="ヌートは現在地で次の手がかりを確かめた。"):
+    def generate(**kwargs):
+        prompt = kwargs["prompt"]
+        if prompt.prompt_id not in {"session.turn_resolution", "session.turn_resolution_repair"}:
+            return original_generate(**kwargs)
+        public_context = kwargs["input_payload"]["public_game_context"]
+        current_location = public_context["current_location"]["name"]
+        raw: dict[str, Any] = {
+            "action_interpretation": "ヌートは強い衝動に駆られて行動した。",
+            "narrative": f"{current_location}で、ヌートは激しい痛みと新たな感覚に襲われた。",
+            "current_situation": f"{current_location}で、ヌートは自分の身に起きた変化を確かめている。",
+            "current_location_name": current_location,
+            "suggested_actions": [
+                {"label": "案内役に今の状態を伝える", "summary": "起きた変化を言葉にして共有する。"},
+                {"label": "周囲の反応を確かめる", "summary": "現在地で見える範囲の変化だけを確認する。"},
+            ],
+            "consequence_summary": "ヌートは自分の状態の変化を主張した。",
+            "world_tags": ["investigate"],
+            "consequence_tags": ["careful_observation"],
+            "self_state_claims": self_state_claims,
+            "outcome_band": outcome_band,
+            "scene_tone": "measured",
+            "scene_move": "deepen",
+            "scene_pressure": scene_pressure,
+            "memories": [{"scope": "world", "text": world_memory_text, "salience": 0.7}],
+            "language_context": {
+                "pack_source_language": "en",
+                "play_language": "ja",
+                "output_language_requested": "ja",
+            },
+            "present_people": [],
+            "public_claims": [
+                {"kind": "location", "surface_text": current_location, "language": "ja", "role": "current_location"},
+            ],
+        }
+        if state_drafts is not None:
+            raw["state_drafts"] = state_drafts
+        return ProviderResponse(raw_output=raw, provider_name="test", provider_response_id=None)
+
+    return generate
+
+
+def test_public_ai_gm_input_includes_player_self_state(client, container, auth_headers):
+    captured_inputs: list[dict[str, Any]] = []
+    original_generate = container.model_router.provider.generate
+
+    def capturing_generate(**kwargs):
+        prompt = kwargs["prompt"]
+        if prompt.prompt_id == "session.turn_resolution":
+            captured_inputs.append(dict(kwargs["input_payload"]))
+        return original_generate(**kwargs)
+
+    container.model_router.provider.generate = capturing_generate
+    try:
+        session_response = client.post("/sessions", json=_session_payload(), headers=auth_headers)
+        assert session_response.status_code == 200
+        _post_turn_and_wait(
+            client,
+            session_response.json()["session_id"],
+            auth_headers,
+            "周囲の様子を確かめる",
+        )
+    finally:
+        container.model_router.provider.generate = original_generate
+
+    assert captured_inputs
+    _assert_no_forbidden_keys(captured_inputs[0])
+    public_context = captured_inputs[0]["public_game_context"]
+    condition = public_context["player_condition"]
+    assert set(condition) == {"vitality", "clarity", "standing"}
+    assert all(isinstance(value, str) and value for value in condition.values())
+    assert isinstance(public_context["player_capabilities"], list)
+    for capability in public_context["player_capabilities"]:
+        assert set(capability) <= {"title", "summary"}
+
+
+def test_unbacked_canonical_self_state_claim_stays_subjective(client, container, auth_headers):
+    original_generate = container.model_router.provider.generate
+    generate = _self_state_turn_generate(
+        original_generate,
+        self_state_claims=[
+            {"kind": "vitality", "surface_text": "死んで蘇った", "persistence": "canonical"},
+            {"kind": "ability", "surface_text": "新たな力を得た", "persistence": "canonical"},
+        ],
+        world_memory_text="ヌートは死から蘇り新たな力を得た。",
+    )
+    container.model_router.provider.generate = generate
+    try:
+        session_response = client.post("/sessions", json=_session_payload(), headers=auth_headers)
+        assert session_response.status_code == 200
+        payload = _post_turn_and_wait(
+            client,
+            session_response.json()["session_id"],
+            auth_headers,
+            "死の淵から蘇り新たな力を得た",
+        )
+    finally:
+        container.model_router.provider.generate = original_generate
+
+    assert payload.get("failure") is None
+    with container.session_factory() as db:
+        turn = db.get(Turn, payload["turn_id"])
+        event = db.get(Event, payload["event_id"])
+        memories = db.execute(select(Memory).where(Memory.source_event_id == payload["event_id"])).scalars().all()
+        assert turn is not None and event is not None
+        assert turn.resolved_output["status"] == "resolved"
+        unconfirmed = turn.resolved_output["unconfirmed_self_claims"]
+        assert {item["kind"] for item in unconfirmed} == {"vitality", "ability"}
+        assert event.payload["unconfirmed_self_claims"] == unconfirmed
+        assert not turn.resolved_output["skill_updates"]
+        # The unbacked subjective experience must not become canonical world fact.
+        assert all("蘇り新たな力" not in memory.text for memory in memories if memory.scope == "world")
+
+
+def test_backed_ability_self_state_claim_materializes_skill(client, container, auth_headers):
+    original_generate = container.model_router.provider.generate
+    generate = _self_state_turn_generate(
+        original_generate,
+        self_state_claims=[
+            {"kind": "ability", "surface_text": "偽装ログ生成の技法", "persistence": "canonical", "backing": "skills"},
+        ],
+        state_drafts={
+            "skills": [
+                {"title": "偽装ログ生成の技法", "summary": "観測を一時的に逸らすため来訪者ログへノイズを編む方法。"}
+            ]
+        },
+    )
+    container.model_router.provider.generate = generate
+    try:
+        session_response = client.post("/sessions", json=_session_payload(), headers=auth_headers)
+        assert session_response.status_code == 200
+        payload = _post_turn_and_wait(
+            client,
+            session_response.json()["session_id"],
+            auth_headers,
+            "偽装ログの生成方法を習得する",
+        )
+    finally:
+        container.model_router.provider.generate = original_generate
+
+    with container.session_factory() as db:
+        turn = db.get(Turn, payload["turn_id"])
+        assert turn is not None
+        assert turn.resolved_output["status"] == "resolved"
+        assert turn.resolved_output["unconfirmed_self_claims"] == []
+        assert turn.resolved_output["skill_updates"]
+        assert any("偽装ログ" in str(item.get("title")) for item in turn.resolved_output["skill_updates"])
+
+
+def test_outcome_band_reflects_ai_gm_narrative_risk(client, container, auth_headers):
+    original_generate = container.model_router.provider.generate
+    generate = _self_state_turn_generate(
+        original_generate,
+        self_state_claims=[],
+        outcome_band="setback",
+        scene_pressure="high",
+        world_memory_text="ヌートは危険な賭けに出て手痛い反動を受けた。",
+    )
+    container.model_router.provider.generate = generate
+    try:
+        session_response = client.post("/sessions", json=_session_payload(), headers=auth_headers)
+        assert session_response.status_code == 200
+        payload = _post_turn_and_wait(
+            client,
+            session_response.json()["session_id"],
+            auth_headers,
+            "危険を承知で霧の奥へ全力で踏み込む",
+        )
+    finally:
+        container.model_router.provider.generate = original_generate
+
+    with container.session_factory() as db:
+        turn = db.get(Turn, payload["turn_id"])
+        assert turn is not None
+        assert turn.resolved_output["status"] == "resolved"
+        # AI GM judged a setback even though no deterministic social tag forced one.
+        assert turn.resolved_output["outcome_band"] == "setback"
+        assert turn.resolved_output["scene_tone"] != "steady"


### PR DESCRIPTION
## Summary
- Add public-safe player self-state context (`player_condition`, `player_capabilities`) to AI GM turn input.
- Add structured `self_state_claims` so unbacked death/revival/new-ability claims are recorded as `unconfirmed_self_claims` instead of canonical world facts.
- Reconcile AI GM `outcome_band` with deterministic consequence band by max severity, and expose `failure_band` for engine-failure setbacks.
- Add regression coverage for self-state context, unbacked/backed self-state claims, outcome-band surfacing, and API response shape.

Closes #8

## Verification
- `PYTHONPATH=backend python -m pytest tests/backend/engine/test_public_ai_gm_contract.py -x -q`
- `PYTHONPATH=backend python -m pytest tests/backend/engine/test_world_slice.py -q`
- `PYTHONPATH=backend python -m pytest tests/backend/engine/test_api_contracts.py tests/backend/engine/test_quest_emergence_gate.py tests/backend/engine/test_openai_compatible_provider.py tests/backend/packs/ashlight_frontier/test_ashlight_frontier_pack.py -q`
- `PYTHONPATH=backend python -m pytest tests/backend -q`
- `make scan-v1-terms`
- `make build-player-frontend`
